### PR TITLE
Disable ColPack examples.

### DIFF
--- a/dependencies/colpack.cmake
+++ b/dependencies/colpack.cmake
@@ -4,6 +4,6 @@ AddDependency(NAME colpack
               GIT_URL https://github.com/chrisdembia/colpack.git
               GIT_TAG master
               CMAKE_ARGS -DCMAKE_DEBUG_POSTFIX:STRING=_d
-                         -DENABLE_EXAMPLES:BOOL=OFF)
+                         -DENABLE_EXAMPLES:BOOL=OFF
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
 


### PR DESCRIPTION
ColPack examples have such long filenames that I get Windows filesystem errors about path names being too long. We don't need to the ColPack examples, so we can disable them.