### PR TITLE
Add tropter::Problem::initialize_on_iterate()

### DIFF
--- a/Muscollo/Muscollo/MucoTropterSolver.cpp
+++ b/Muscollo/Muscollo/MucoTropterSolver.cpp
@@ -175,6 +175,11 @@ public:
     void initialize_on_mesh(const Eigen::VectorXd&) const override {
         m_mucoProb.initialize(m_model);
     }
+    void initialize_on_iterate(const Eigen::VectorXd& parameters)
+            const override {
+        // If they exist, apply parameter values to the model.
+        this->applyParametersToModel(parameters);
+    }
     // TODO rename argument "states" to "state".
     void calc_differential_algebraic_equations(
             const tropter::DAEInput<T>& in,
@@ -184,10 +189,6 @@ public:
 
         const auto& states = in.states;
         const auto& controls = in.controls;
-        const auto& parameters = in.parameters;
-
-        // If they exist, apply parameter values to the model.
-        this->applyParametersToModel(parameters);
 
         m_state.setTime(in.time);
         std::copy(states.data(), states.data() + states.size(),
@@ -217,8 +218,6 @@ public:
             const VectorX<T>& states,
             const VectorX<T>& controls, 
             const VectorX<T>& parameters, T& integrand) const override {
-        // If they exist, apply parameter values to the model.
-        this->applyParametersToModel(parameters);
         // TODO would it make sense to a vector of States, one for each mesh
         // point, so that each can preserve their cache?
         m_state.setTime(time);
@@ -237,8 +236,6 @@ public:
     }
     void calc_endpoint_cost(const T& final_time, const VectorX<T>& states,
             const VectorX<T>& parameters, T& cost) const override {
-        // If they exist, apply parameter values to the model.
-        this->applyParametersToModel(parameters);
         // TODO avoid all of this if there are no endpoint costs.
         m_state.setTime(final_time);
         std::copy(states.data(), states.data() + states.size(),
@@ -254,7 +251,6 @@ private:
     const MucoPhase& m_phase0;
     mutable Model m_model;
     mutable SimTK::State m_state;
-    // TODO: mutable SimTK::Vector m_mucoParams;
 
     void applyParametersToModel(const VectorX<T>& parameters) const
     {

--- a/tropter/tropter/optimalcontrol/Problem.h
+++ b/tropter/tropter/optimalcontrol/Problem.h
@@ -252,6 +252,13 @@ public:
     ///             points are normalized and are thus within [0, 1].
     virtual void initialize_on_mesh(const Eigen::VectorXd& mesh) const;
 
+    /// This function is invoked every time there is a new iterate (perhaps
+    /// multiple times), and allows you to perform any initialization or caching
+    /// based on the constant parameter values from the iterate, in case this is
+    /// expensive. Implementing this function is optional, even if your problem
+    /// has parameters.
+    virtual void initialize_on_iterate(const VectorX<T>& parameters) const;
+
     /// Compute the right-hand side of the differntial algebraic equations
     /// (DAE) for the system you want to optimize. This is the function that
     /// provides the dynamics and path constraints.

--- a/tropter/tropter/optimalcontrol/Problem.hpp
+++ b/tropter/tropter/optimalcontrol/Problem.hpp
@@ -125,6 +125,11 @@ void Problem<T>::
 initialize_on_mesh(const Eigen::VectorXd&) const
 {}
 
+template<typename T>
+void Problem<T>::
+initialize_on_iterate(const VectorX<T>&) const
+{}
+
 template<typename T>    
 void Problem<T>::
 calc_differential_algebraic_equations(const DAEInput<T>&, DAEOutput<T>) const

--- a/tropter/tropter/optimalcontrol/transcription/Trapezoidal.hpp
+++ b/tropter/tropter/optimalcontrol/transcription/Trapezoidal.hpp
@@ -162,6 +162,10 @@ void Trapezoidal<T>::calc_objective(const VectorX<T>& x, T& obj_value) const
     auto controls = make_controls_trajectory_view(x);
     auto parameters = make_parameters_view(x);
 
+    // Initialize on iterate.
+    // ----------------------
+    m_ocproblem->initialize_on_iterate(parameters);
+
     // Endpoint cost.
     // --------------
     // TODO does this cause the final_states to get copied?
@@ -202,6 +206,10 @@ void Trapezoidal<T>::calc_constraints(const VectorX<T>& x,
     auto states = make_states_trajectory_view(x);
     auto controls = make_controls_trajectory_view(x);
     auto parameters = make_parameters_view(x);
+
+    // Initialize on iterate.
+    // ======================
+    m_ocproblem->initialize_on_iterate(parameters);
 
     // Organize the constrants vector.
     ConstraintsView constr_view = make_constraints_view(constraints);


### PR DESCRIPTION
Using this function to process the parameters only a few times per
iterate, rather than for each mesh point, speeds up testMucoParameters from 22 seconds to 2 seconds.

There is still more we can do to speed up the problem when using parameters. Ideally, we would not call `initialize_on_parameters()` in the DAE function, the endpoint, and the integral functions, but just once. I'll leave these larger changes to when/if we make overall performance improvements.

@nickbianco could you review this?