### PR TITLE
Constraints: direct collocation tests.

### DIFF
--- a/Muscollo/Tests/testConstraints.cpp
+++ b/Muscollo/Tests/testConstraints.cpp
@@ -468,8 +468,7 @@ void testDoublePendulumCoordinateCoupler(MucoSolution& solution) {
     // this linear function couples the two model coordinates such that given 
     // the boundary conditions for q0 from testDoublePendulumPointOnLine, the
     // same boundary conditions for q1 should be achieved without imposing 
-    // bounds for this coordinate. Note that the full trajectory may differ, 
-    // since the point-on-line constraint is no longer in place.
+    // bounds for this coordinate.
     const SimTK::Real m = -2;
     const SimTK::Real b = SimTK::Pi;
     LinearFunction linFunc = LinearFunction(m, b);


### PR DESCRIPTION
This PR implements the direct collocation tests proposed in #137. The three subtests feature a double inverted pendulum model subject to either a 1) point-on-line constraint, 2) a coordinate coupler constraint, or 3) a prescribed motion constraint. 

Note: there are some "TODO" comments for some things that may need to be revised once all of the features described in #137 are in place. 