### PR TITLE
Wrap MocoTool.

### DIFF
--- a/Moco/Bindings/moco.i
+++ b/Moco/Bindings/moco.i
@@ -188,6 +188,7 @@ namespace OpenSim {
 %include <Moco/MocoCasADiSolver/MocoCasADiSolver.h>
 %include <Moco/MocoStudy.h>
 
+%include <Moco/MocoTool.h>
 %include <Moco/MocoInverse.h>
 
 %include <Moco/Components/ActivationCoordinateActuator.h>

--- a/Moco/Moco/MocoTool.h
+++ b/Moco/Moco/MocoTool.h
@@ -56,6 +56,7 @@ public:
     void setModel(ModelProcessor model) { set_model(std::move(model)); }
 
 protected:
+#ifndef SWIG
     struct TimeInfo {
         double initial = -SimTK::Infinity;
         double final = SimTK::Infinity;
@@ -70,7 +71,7 @@ protected:
     /// mesh_interval property.
     void updateTimeInfo(const std::string& dataLabel, const double& dataInitial,
             const double& dataFinal, TimeInfo& info) const;
-
+#endif
 private:
     void constructProperties();
 };


### PR DESCRIPTION
This PR wraps the MocoTool base class so MocoInverse, etc. have setModel().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/296)
<!-- Reviewable:end -->
