### PR TITLE
Bump VS version in superbuild and eigen version

### DIFF
--- a/build_on_windows.ps1
+++ b/build_on_windows.ps1
@@ -9,12 +9,12 @@ git submodule update --init
 mkdir ..\moco_dependencies_build
 cd ..\moco_dependencies_build
 cmake ..\opensim-moco\dependencies `
-    -G"Visual Studio 14 2015 Win64"
+    -G"Visual Studio 15 2017 Win64"
 cmake --build . --config RelWithDebInfo -- /maxcpucount:8
 mkdir ..\build
 cd ..\build
 cmake ..\opensim-moco `
-    -G"Visual Studio 14 2015 Win64"
+    -G"Visual Studio 15 2017 Win64"
 cmake --build . --config RelWithDebInfo -- /maxcpucount:8
 ctest --build-config RelWithDebInfo --parallel 8
 cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ SetDefaultCMakeBuildType()
 ####################### Add dependencies below.
 
 AddDependency(NAME eigen
-              URL  https://bitbucket.org/eigen/eigen/get/3.3.4.zip)
+              URL  https://bitbucket.org/eigen/eigen/get/3.3.7.zip)
 
 include(colpack.cmake)
 


### PR DESCRIPTION
Fixes issue #286. Testing with new commits to master seems to have also resolved #289. This commit does the following:
1) bump superbuild for Windows to use VS2017
2) bump eigen to 3.3.7