### PR TITLE
[travis] Fix bash scripts to propagate errors

### DIFF
--- a/.github/travis_buildtest.sh
+++ b/.github/travis_buildtest.sh
@@ -1,4 +1,7 @@
-bash .github/travis_common.sh  
+# Terminate on error, print every line
+set -ev
+
+bash .github/travis_common.sh
 
 # Download dependencies
 wget https://sourceforge.net/projects/myosin/files/opensim-moco/opensim-moco-dep-opensim-core.zip/download -O ~/opensim-moco-dep-opensim-core.zip

--- a/.github/travis_common.sh
+++ b/.github/travis_common.sh
@@ -1,3 +1,6 @@
+# Terminate on error, print every line
+set -ev
+
 cd $TRAVIS_BUILD_DIR
 # Stop build if comment contains [skip travis].
 if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 

--- a/.github/travis_dependencies.sh
+++ b/.github/travis_dependencies.sh
@@ -1,4 +1,7 @@
-bash .github/travis_common.sh 
+# Terminate on error, print every line
+set -ev
+
+bash .github/travis_common.sh
 
 # Run superbuild to download, configure, build and install dependencies.
 mkdir $TRAVIS_BUILD_DIR/../opensim-moco_dependencies_build


### PR DESCRIPTION
Currently, errors in bash scripts do not cause Travis CI to fail. This PR fixes that.

-e: terminate script upon first error.
-v: print each command before running it.