### PR TITLE
Fix intermediateCallback counter.

### DIFF
--- a/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -65,9 +65,9 @@ public:
                             iterate.variables[final_time]);
             iterate.iteration = evalCount;
             m_problem.intermediateCallbackWithIterate(iterate);
-            evalCount++;
         }
         m_problem.intermediateCallback();
+        ++evalCount;
         return {0};
     }
 


### PR DESCRIPTION
The line that incremented the counter for the number of callback evaluations was in the wrong location previously, causing intermediate iterates to not be written to file. This PR fixes that bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/364)
<!-- Reviewable:end -->
