### PR TITLE
MocoTool::getDocumentDirectory()

### DIFF
--- a/Moco/Moco/MocoInverse.cpp
+++ b/Moco/Moco/MocoInverse.cpp
@@ -44,22 +44,13 @@ void MocoInverse::constructProperties() {
 MocoStudy MocoInverse::initialize() const { return initializeInternal().first; }
 
 std::pair<MocoStudy, TimeSeriesTable> MocoInverse::initializeInternal() const {
-    using SimTK::Pathname;
-    // Get the directory containing the setup file.
-    std::string setupDir;
-    {
-        bool dontApplySearchPath;
-        std::string fileName, extension;
-        Pathname::deconstructPathname(getDocumentFileName(),
-                dontApplySearchPath, setupDir, fileName, extension);
-    }
 
     // Process inputs.
     // ----------------
-    Model model = get_model().process();
+    Model model = get_model().process(getDocumentDirectory());
     model.initSystem();
 
-    TimeSeriesTable kinematics = get_kinematics().process(setupDir, &model);
+    TimeSeriesTable kinematics = get_kinematics().process(getDocumentDirectory(), &model);
 
     // Prescribe the kinematics.
     // -------------------------

--- a/Moco/Moco/MocoTool.cpp
+++ b/Moco/Moco/MocoTool.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 #include "MocoTool.h"
+
 #include "MocoUtilities.h"
 
 using namespace OpenSim;
@@ -71,17 +72,23 @@ void MocoTool::updateTimeInfo(const std::string& dataLabel,
 
 std::string MocoTool::getFilePath(const std::string& file) const {
     using SimTK::Pathname;
+
+    const std::string setupDir = getDocumentDirectory();
+
+    const std::string filepath =
+            Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(
+                    setupDir, file);
+
+    return filepath;
+}
+
+std::string MocoTool::getDocumentDirectory() const {
     std::string setupDir;
     {
         bool dontApplySearchPath;
         std::string fileName, extension;
-        Pathname::deconstructPathname(getDocumentFileName(),
-            dontApplySearchPath, setupDir, fileName, extension);
+        SimTK::Pathname::deconstructPathname(getDocumentFileName(),
+                dontApplySearchPath, setupDir, fileName, extension);
     }
-
-    std::string filepath =
-        Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(
-            setupDir, file);
-
-    return filepath;
+    return setupDir;
 }

--- a/Moco/Moco/MocoTool.h
+++ b/Moco/Moco/MocoTool.h
@@ -99,6 +99,11 @@ protected:
     /// to conform to the current platform.
     std::string getFilePath(const std::string& file) const;
 
+    /// Get the (canonicalized) absolute directory containing the file from
+    /// which this tool was loaded. If the tool was not loaded from a file, this
+    /// returns an empty string.
+    std::string getDocumentDirectory() const;
+
 #endif
 private:
     void constructProperties();

--- a/Moco/Moco/MocoTrack.cpp
+++ b/Moco/Moco/MocoTrack.cpp
@@ -57,7 +57,7 @@ MocoStudy MocoTrack::initialize() {
 
     // Modeling.
     // ---------
-    Model model = get_model().process();
+    Model model = get_model().process(getDocumentDirectory());
     model.initSystem();
 
     // Costs.
@@ -145,7 +145,8 @@ TimeSeriesTable MocoTrack::configureStateTracking(MocoProblem& problem,
         Model& model) {
 
     // Read in the states reference data and spline.
-    TimeSeriesTable states = get_states_reference().process("", &model);
+    TimeSeriesTable states =
+            get_states_reference().process(getDocumentDirectory(), &model);
     auto stateSplines = GCVSplineSet(states, states.getColumnLabels());
 
     // Loop through all coordinates and compare labels in the reference data
@@ -234,7 +235,8 @@ TimeSeriesTable MocoTrack::configureStateTracking(MocoProblem& problem,
 void MocoTrack::configureMarkerTracking(MocoProblem& problem, Model& model) {
 
     // Read in the markers reference data.
-    TimeSeriesTable markersFlat = get_markers_reference().process("", &model);
+    TimeSeriesTable markersFlat =
+            get_markers_reference().process(getDocumentDirectory(), &model);
     TimeSeriesTable_<SimTK::Vec3> markers = markersFlat.pack<SimTK::Vec3>();
     MarkersReference markersRef(markers);
 


### PR DESCRIPTION
This PR introduces a function to MocoTool, `getDocumentDirectory()`, and uses this to create an argument to the Processors' `process()`. This PR helps the MocoTools find models and kinematics files in the correct location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/393)
<!-- Reviewable:end -->
