### PR TITLE
Create MOCO_DEPENDENCIES_DIR CMake setting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,22 +62,23 @@ endif()
 
 # Default paths for finding dependencies.
 set(MOCO_DEPENDENCIES_DIR
-        "${CMAKE_SOURCE_DIR}/../moco_dependencies_install")
-get_filename_component(MOCO_DEPENDENCIES_DIR "${MOCO_DEPENDENCIES_DIR}"
+        "${CMAKE_SOURCE_DIR}/../moco_dependencies_install" CACHE PATH
+        "The install prefix for the dependencies CMake project.")
+get_filename_component(MOCO_DEPENDENCIES_ABSDIR "${MOCO_DEPENDENCIES_DIR}"
         ABSOLUTE)
 if(NOT CMAKE_PREFIX_PATH
         AND NOT ADOLC_DIR AND NOT "$ENV{ADOLC_DIR}"
         AND NOT IPOPT_DIR AND NOT "$ENV{IPOPT_DIR}"
-        AND EXISTS "${MOCO_DEPENDENCIES_DIR}")
+        AND EXISTS "${MOCO_DEPENDENCIES_ABSDIR}")
     message(STATUS
-            "Attempting to use dependencies from ${MOCO_DEPENDENCIES_DIR}")
+            "Attempting to use dependencies from ${MOCO_DEPENDENCIES_ABSDIR}")
     set(dep_install_dirs)
     foreach(dep opensim-core colpack ipopt eigen casadi)
-        list(APPEND dep_install_dirs "${MOCO_DEPENDENCIES_DIR}/${dep}")
+        list(APPEND dep_install_dirs "${MOCO_DEPENDENCIES_ABSDIR}/${dep}")
     endforeach()
     set(CMAKE_PREFIX_PATH "${dep_install_dirs}" CACHE PATH
             "Directories containing dependencies.")
-    set(ADOLC_DIR "${MOCO_DEPENDENCIES_DIR}/adol-c" CACHE PATH
+    set(ADOLC_DIR "${MOCO_DEPENDENCIES_ABSDIR}/adol-c" CACHE PATH
             "Path to ADOL-C install directory.")
 endif()
 


### PR DESCRIPTION
This CMake setting removes the hard-coding of where dependencies must be installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/425)
<!-- Reviewable:end -->
