### PR TITLE
Create a CMake target for MocoCheatSheet

### DIFF
--- a/Moco/doc/CMakeLists.txt
+++ b/Moco/doc/CMakeLists.txt
@@ -25,3 +25,27 @@ if(DOXYGEN_FOUND)
             DESTINATION "${CMAKE_INSTALL_DOCDIR}/")
 
 endif()
+
+find_package(LATEX COMPONENTS PDFLATEX)
+
+set_package_properties(LATEX PROPERTIES
+        URL https://www.latex-project.org/
+        TYPE OPTIONAL
+        PURPOSE "Building the MocoCheatSheet PDF.")
+
+if(LATEX_PDFLATEX_FOUND)
+    add_custom_target(MocoCheatSheet
+            COMMENT "MocoCheatSheet LaTeX PDF"
+            SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/MocoCheatSheet.tex")
+    set_target_properties(MocoCheatSheet PROPERTIES
+            PROJECT_LABEL "MocoCheatSheet" FOLDER "Moco")
+    add_custom_command(TARGET MocoCheatSheet
+            COMMENT "Running pdflatex to build MocoCheatSheet."
+            COMMAND "${PDFLATEX_COMPILER}"
+                    "-output-directory='${CMAKE_CURRENT_BINARY_DIR}'"
+                    "MocoCheatSheet.tex"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/MocoCheatSheet.pdf"
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}/")
+endif()


### PR DESCRIPTION
This PR creates a CMake target for the MocoCheatSheet.

Maybe one day we can also build the MocoCheatSheet on Travis/AppVeyor. But for now I would rather not deal with getting LaTeX on the CI machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/440)
<!-- Reviewable:end -->
