### PR TITLE
DGF::replaceMuscles(): copy appliesForce.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2019-10-27: DeGrooteFregly2016Muscle::replaceMuscles() now carries over the
+              appliesForce property. This affects 
+              ModOpReplaceMusclesWithDeGrooteFregly2016 as well.
+
 - 2019-10-19: configureMoco.m adds Moco's Matlab Utilities directory
               to the Matlab path, and removes any detected OpenSense beta
               installations from Matlab.

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
@@ -989,6 +989,7 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
         // Perform all the common mappings at base class level (OpenSim::Muscle)
         actu->setName(muscBase.getName());
         muscBase.setName(muscBase.getName() + "_delete");
+        actu->set_appliesForce(muscBase.get_appliesForce());
         actu->setMinControl(muscBase.getMinControl());
         actu->setMaxControl(muscBase.getMaxControl());
 


### PR DESCRIPTION
Fixes issue #484 

### Brief summary of changes

This PR causes `DeGrooteFregly2016Muscle::replaceMuscles()` to copy the `appliesForce` property.

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/485)
<!-- Reviewable:end -->
