### PR TITLE
Fix connectee paths in replaceMusclesWithPathActuators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-
 - 2019-10-30: ModelFactory::replaceMusclesWithPathActuators() now adds the
               PathActuators to the Model's ForceSet, and the connectee names
               for PathPoints are now valid.
 
 - 2019-10-30: Solvers print the date and time before and after solving a 
               problem.
-
 
 - 2019-10-19: configureMoco.m adds Moco's Matlab Utilities directory
               to the Matlab path, and removes any detected OpenSense beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2019-10-30: ModelFactory::replaceMusclesWithPathActuators() now adds the
+              PathActuators to the Model's ForceSet, and the connectee names
+              for PathPoints are now valid.
+
 - 2019-10-19: configureMoco.m adds Moco's Matlab Utilities directory
               to the Matlab path, and removes any detected OpenSense beta
               installations from Matlab.

--- a/Moco/Moco/Components/ModelFactory.cpp
+++ b/Moco/Moco/Components/ModelFactory.cpp
@@ -133,8 +133,8 @@ void ModelFactory::replaceMusclesWithPathActuators(OpenSim::Model &model) {
     // a list of pointers of the muscles to delete.
     std::vector<Muscle*> musclesToDelete;
     auto& muscleSet = model.updMuscles();
-    for (int i = 0; i < muscleSet.getSize(); ++i) {
-        auto& musc = muscleSet.get(i);
+    for (int im = 0; im < muscleSet.getSize(); ++im) {
+        auto& musc = muscleSet.get(im);
         auto* actu = new PathActuator();
         actu->setName(musc.getName());
         musc.setName(musc.getName() + "_delete");
@@ -142,20 +142,24 @@ void ModelFactory::replaceMusclesWithPathActuators(OpenSim::Model &model) {
         actu->setMinControl(musc.getMinControl());
         actu->setMaxControl(musc.getMaxControl());
 
+        model.addForce(actu);
+
+        // For the connectee names in the PathPoints to be correct, we must add
+        // the path points after adding the PathActuator to the model.
         const auto& pathPointSet = musc.getGeometryPath().getPathPointSet();
         auto& geomPath = actu->updGeometryPath();
-        for (int i = 0; i < pathPointSet.getSize(); ++i) {
-            auto* pathPoint = pathPointSet.get(i).clone();
+        for (int ip = 0; ip < pathPointSet.getSize(); ++ip) {
+            auto* pathPoint = pathPointSet.get(ip).clone();
             const auto& socketNames = pathPoint->getSocketNames();
             for (const auto& socketName : socketNames) {
                 pathPoint->updSocket(socketName)
-                        .connect(pathPointSet.get(i)
-                                         .getSocket(socketName)
-                                         .getConnecteeAsObject());
+                        .connect(pathPointSet.get(ip)
+                                .getSocket(socketName)
+                                .getConnecteeAsObject());
             }
             geomPath.updPathPointSet().adoptAndAppend(pathPoint);
         }
-        model.addComponent(actu);
+
         musclesToDelete.push_back(&musc);
     }
 

--- a/Moco/Moco/MocoInverse.cpp
+++ b/Moco/Moco/MocoInverse.cpp
@@ -124,6 +124,23 @@ std::pair<MocoStudy, TimeSeriesTable> MocoInverse::initializeInternal() const {
         solver.set_optim_max_iterations(get_max_iterations());
     }
 
+    // MocoTrajectory guess = solver.createGuess();
+    // int N = guess.getNumTimes();
+    // double guessValue = 0.05;
+    // for (const auto& muscle : model.getComponentList<Muscle>()) {
+    //     if (muscle.get_appliesForce()) {
+    //         // TODO: base on upper and lower bounds.
+    //         guess.setControl(muscle.getAbsolutePathString(),
+    //                 SimTK::Vector(N, guessValue));
+    //         if (!muscle.get_ignore_activation_dynamics()) {
+    //             guess.setState(muscle.getAbsolutePathString() + "/activation",
+    //                     SimTK::Vector(N, guessValue));
+    //         }
+    //     }
+    // }
+    // solver.setGuess(guess);
+
+
     return std::make_pair(
             study, posmotPtr->exportToTable(kinematics.getIndependentColumn()));
 }

--- a/Moco/Moco/MocoInverse.cpp
+++ b/Moco/Moco/MocoInverse.cpp
@@ -123,24 +123,6 @@ std::pair<MocoStudy, TimeSeriesTable> MocoInverse::initializeInternal() const {
     if (!getProperty_max_iterations().empty()) {
         solver.set_optim_max_iterations(get_max_iterations());
     }
-
-    // MocoTrajectory guess = solver.createGuess();
-    // int N = guess.getNumTimes();
-    // double guessValue = 0.05;
-    // for (const auto& muscle : model.getComponentList<Muscle>()) {
-    //     if (muscle.get_appliesForce()) {
-    //         // TODO: base on upper and lower bounds.
-    //         guess.setControl(muscle.getAbsolutePathString(),
-    //                 SimTK::Vector(N, guessValue));
-    //         if (!muscle.get_ignore_activation_dynamics()) {
-    //             guess.setState(muscle.getAbsolutePathString() + "/activation",
-    //                     SimTK::Vector(N, guessValue));
-    //         }
-    //     }
-    // }
-    // solver.setGuess(guess);
-
-
     return std::make_pair(
             study, posmotPtr->exportToTable(kinematics.getIndependentColumn()));
 }


### PR DESCRIPTION
Fixes issue #<issue_number>

### Brief summary of changes

This PR fixes connectee paths for `PathPoint`s when using `ModelFactory::replaceMusclesWithPathActuators`.

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/489)
<!-- Reviewable:end -->
