### PR TITLE
Solvers print datetime.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 2019-10-30: Solvers print the date and time before and after solving a 
+              problem.
+
 - 2019-10-19: configureMoco.m adds Moco's Matlab Utilities directory
               to the Matlab path, and removes any detected OpenSense beta
               installations from Matlab.

--- a/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -308,7 +308,8 @@ MocoSolution MocoCasADiSolver::solveImpl() const {
 
     if (get_verbosity()) {
         std::cout << std::string(79, '=') << "\n";
-        std::cout << "MocoCasADiSolver starting.\n";
+        std::cout << "MocoCasADiSolver starting. ";
+        std::cout << getFormattedDateTime(false, "%c") << "\n";
         std::cout << std::string(79, '-') << std::endl;
         getProblemRep().printDescription();
     }
@@ -400,6 +401,7 @@ MocoSolution MocoCasADiSolver::solveImpl() const {
         std::cout << std::string(79, '-') << "\n";
         std::cout << "Elapsed real time: " << stopwatch.formatNs(elapsed)
                   << ".\n";
+        std::cout << getFormattedDateTime(false, "%c") << "\n";
         if (mocoSolution) {
             std::cout << "MocoCasADiSolver succeeded!\n";
         } else {

--- a/Moco/Moco/MocoTropterSolver.cpp
+++ b/Moco/Moco/MocoTropterSolver.cpp
@@ -308,7 +308,7 @@ MocoSolution MocoTropterSolver::solveImpl() const {
     // Problem print information is verbosity 1 or 2.
     if (get_verbosity()) {
         std::cout << std::string(79, '=') << "\n";
-        std::cout << "MocoTropterSolver starting.\n";
+        std::cout << "MocoTropterSolver starting. ";
         std::cout << getFormattedDateTime(false, "%c") << "\n";
         std::cout << std::string(79, '-') << std::endl;
         getProblemRep().printDescription();

--- a/Moco/Moco/MocoTropterSolver.cpp
+++ b/Moco/Moco/MocoTropterSolver.cpp
@@ -309,6 +309,7 @@ MocoSolution MocoTropterSolver::solveImpl() const {
     if (get_verbosity()) {
         std::cout << std::string(79, '=') << "\n";
         std::cout << "MocoTropterSolver starting.\n";
+        std::cout << getFormattedDateTime(false, "%c") << "\n";
         std::cout << std::string(79, '-') << std::endl;
         getProblemRep().printDescription();
     }
@@ -392,6 +393,7 @@ MocoSolution MocoTropterSolver::solveImpl() const {
         std::cout << std::string(79, '-') << "\n";
         std::cout << "Elapsed real time: " << stopwatch.formatNs(elapsed)
                   << ".\n";
+        std::cout << getFormattedDateTime(false, "%c") << "\n";
         if (mocoSolution) {
             std::cout << "MocoTropterSolver succeeded!\n";
         } else {


### PR DESCRIPTION
Fixes issue #379 

### Brief summary of changes

This PR prints out the date/time at the start and end of solving a problem.

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanfordnmbl/opensim-moco/490)
<!-- Reviewable:end -->
