### PR TITLE
[WIP] Treat warnings as errors with MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -132,8 +132,7 @@ build_script:
   # Install Moco.
   - mkdir ..\build
   - cd ..\build
-  # Turn warnings into errors (/WX)
-  - cmake -E env CXXFLAGS="/WX" cmake ..\opensim-moco -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="C:\opensim-moco" -DADOLC_DIR="..\deps\adol-c" -DCMAKE_PREFIX_PATH="C:\projects\deps\eigen;C:\projects\deps\colpack;C:\projects\deps\opensim-core;C:\projects\deps\ipopt;C:\projects\deps\casadi;C:\projects\deps\casadi\casadi" -DMOCO_PYTHON_BINDINGS=ON -DMOCO_JAVA_BINDINGS=ON
+  - cmake ..\opensim-moco -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="C:\opensim-moco" -DADOLC_DIR="..\deps\adol-c" -DCMAKE_PREFIX_PATH="C:\projects\deps\eigen;C:\projects\deps\colpack;C:\projects\deps\opensim-core;C:\projects\deps\ipopt;C:\projects\deps\casadi;C:\projects\deps\casadi\casadi" -DMOCO_PYTHON_BINDINGS=ON -DMOCO_JAVA_BINDINGS=ON
   #-DCMAKE_TOOLCHAIN_FILE="C:\Tools\vcpkg\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --config %BTYPE% -- /maxcpucount:4 /verbosity:minimal
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,14 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang # includes AppleClang
         add_compile_options(-Wno-unused-local-typedef)
     endif()
 endif()
+if(MSVC)
+    # Treat warnings as errors.
+    # Ideally we would increase the warning level to 4 but that generates
+    # lots of warnings in our dependencies.
+    # Convert warning 4388 ('operator' signed/unsigned mismatch) from
+    # level 4 to level 3 for consistency with Clang.
+    add_compile_options(/WX /w34388) # /W4
+endif()
 
 # TODO add /WX flag for Windows.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,6 @@ if(MSVC)
     add_compile_options(/WX /w34388) # /W4
 endif()
 
-# TODO add /WX flag for Windows.
-
 enable_testing()
 include(CTest)
 

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
@@ -93,7 +93,7 @@ void MocoSumSquaredStateGoal::initializeOnModelImpl(const Model& model) const {
 
 void MocoSumSquaredStateGoal::calcIntegrandImpl(
         const SimTK::State& state, double& integrand) const {
-    for (int i = 0; i < m_state_weights.size(); ++i) {
+    for (int i = 0; i < (int)m_state_weights.size(); ++i) {
         const auto& value = state.getY()[m_sysYIndices[i]];
         integrand += m_state_weights[i] * value * value;
     }

--- a/Moco/Tests/testMocoInterface.cpp
+++ b/Moco/Tests/testMocoInterface.cpp
@@ -1230,7 +1230,7 @@ TEMPLATE_TEST_CASE("Guess", "", MocoTropterSolver, MocoCasADiSolver) {
         CHECK(explicitGuess.getDerivativeNames().empty());
         explicitGuess.generateAccelerationsFromSpeeds();
         // Only one coordinate in the sliding mass model.
-        CHECK(explicitGuess.getDerivativeNames().size() == 1);
+        CHECK((int)explicitGuess.getDerivativeNames().size() == 1);
     }
 
     // TODO ordering of states and controls in MocoTrajectory should not

--- a/Moco/Tests/testTableProcessor.cpp
+++ b/Moco/Tests/testTableProcessor.cpp
@@ -57,7 +57,7 @@ TEST_CASE("TableProcessor") {
 
     SECTION("Operators take effect") {
         TableProcessor proc = TableProcessor(table) | MyTableOperator();
-        CHECK(proc.process().getNumRows() == 4);
+        CHECK((int)proc.process().getNumRows() == 4);
     }
 
     SECTION("Serialization") {
@@ -73,7 +73,7 @@ TEST_CASE("TableProcessor") {
                     "testTableProcessor_TableProcessor.xml"));
             auto* proc = dynamic_cast<TableProcessor*>(obj.get());
             TimeSeriesTable out = proc->process();
-            CHECK(out.getNumRows() == 4);
+            CHECK((int)out.getNumRows() == 4);
         }
     }
 }

--- a/tropter/tests/test_derivatives.cpp
+++ b/tropter/tests/test_derivatives.cpp
@@ -855,13 +855,13 @@ public:
         VectorXd guess = decorator->make_initial_guess_from_bounds();
         problem.guess = &guess;
         solver.calc_sparsity(guess, jac_sparsity, false, hes_sparsity);
-        REQUIRE(jac_sparsity.row.size() == 3);
-        REQUIRE(jac_sparsity.col.size() == 3);
+        REQUIRE((int)jac_sparsity.row.size() == 3);
+        REQUIRE((int)jac_sparsity.col.size() == 3);
 
         solver.set_sparsity_detection("random");
         solver.calc_sparsity(guess, jac_sparsity, false, hes_sparsity);
-        REQUIRE(jac_sparsity.row.size() == 2);
-        REQUIRE(jac_sparsity.col.size() == 2);
+        REQUIRE((int)jac_sparsity.row.size() == 2);
+        REQUIRE((int)jac_sparsity.col.size() == 2);
 
         REQUIRE_THROWS(solver.set_sparsity_detection("invalid"));
     }

--- a/tropter/tropter/common.h
+++ b/tropter/tropter/common.h
@@ -18,9 +18,9 @@
 
 #ifdef _MSC_VER
     // Ignore warnings from ADOL-C headers.
-    #pragma warning(push)
+    #pragma warning(push, 0)
     // 'argument': conversion from 'size_t' to 'locint', possible loss of data.
-    #pragma warning(disable: 4267)
+    // #pragma warning(disable: 4267)
 #endif
 #include <adolc/adouble.h>
 #ifdef _MSC_VER

--- a/tropter/tropter/optimization/IPOPTSolver.cpp
+++ b/tropter/tropter/optimization/IPOPTSolver.cpp
@@ -17,9 +17,16 @@
 #include "Problem.h"
 #include <tropter/SparsityPattern.h>
 #include <tropter/Exception.hpp>
+#ifdef _MSC_VER
+    // Ignore warnings from Ipopt headers.
+    #pragma warning(push, 0)
+#endif
 #include <IpTNLP.hpp>
 #include <IpIpoptApplication.hpp>
 #include <IpIpoptData.hpp>
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
 using Eigen::VectorXd;
 using Eigen::MatrixXd;
 using Eigen::Ref;


### PR DESCRIPTION
Fixes issue #498

### Brief summary of changes

This PR warns about signed/unsigned comparisons with MSVC for consistency with Clang and turns MSVC warnings into errors. However, this causes OpenSim to generate warnings. Before we can merge this, we need to fix the warnings in OpenSim.

### CHANGELOG.md (choose one)

- [ ] updated
- [ ] no need to update because...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/500)
<!-- Reviewable:end -->
