### PR TITLE
Remove DGF include in MocoProblemRep

### DIFF
--- a/Moco/Moco/MocoProblemRep.cpp
+++ b/Moco/Moco/MocoProblemRep.cpp
@@ -19,7 +19,6 @@
 #include "MocoProblemRep.h"
 
 #include "Components/AccelerationMotion.h"
-#include "Components/DeGrooteFregly2016Muscle.h"
 #include "Components/DiscreteForces.h"
 #include "Components/PositionMotion.h"
 #include "MocoProblem.h"


### PR DESCRIPTION
### Brief summary of changes

No longer include the DGF header in MocoProblemRep.

### Details (optional)

### CHANGELOG.md (choose one)

- [x] no need to update because...does not affect users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/508)
<!-- Reviewable:end -->
