### PR TITLE
fix c++, matlab, and python examples (except exampleTracking)

### DIFF
--- a/Moco/Bindings/Java/Matlab/CMakeLists.txt
+++ b/Moco/Bindings/Java/Matlab/CMakeLists.txt
@@ -26,6 +26,8 @@ file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
     "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
 install(FILES ${GEOMETRY}
     DESTINATION "${MOCO_INSTALL_MATLABEXDIR}/exampleSitToStand/Geometry")
+install(FILES ${GEOMETRY}
+    DESTINATION "${MOCO_INSTALL_MATLABEXDIR}/exampleMarkerTracking10DOF/Geometry")
 
 # The configureMoco.m script contains paths into the Moco installation
 # that may be different on different platforms, so we configure it with CMake

--- a/Moco/Bindings/Java/Matlab/Examples/exampleMarkerTracking10DOF/exampleMarkerTracking10DOF.m
+++ b/Moco/Bindings/Java/Matlab/Examples/exampleMarkerTracking10DOF/exampleMarkerTracking10DOF.m
@@ -105,7 +105,7 @@ problem.addGoal(markerTrackingCost);
 % Add a low-weighted control effort cost to reduce oscillations in the 
 % actuator controls.
 controlCost = MocoControlGoal();
-controlCost.set_weight(0.001);
+controlCost.setWeight(0.001);
 problem.addGoal(controlCost);
 
 % Configure the solver.

--- a/Moco/Bindings/Java/Matlab/Examples/exampleMarkerTracking10DOF/subject01.osim
+++ b/Moco/Bindings/Java/Matlab/Examples/exampleMarkerTracking10DOF/subject01.osim
@@ -334,7 +334,7 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>femur.vtp</geometry_file>
+									<geometry_file>femur_r.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 1 1 1</color>
 									<!--Name of texture file .jpg, .bmp-->
@@ -515,7 +515,7 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>tibia.vtp</geometry_file>
+									<geometry_file>tibia_r.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 1 1 1</color>
 									<!--Name of texture file .jpg, .bmp-->

--- a/Moco/Bindings/Java/Matlab/Examples/exampleMinimizeJointReaction.m
+++ b/Moco/Bindings/Java/Matlab/Examples/exampleMinimizeJointReaction.m
@@ -31,7 +31,7 @@ runInvertedPendulumProblem('minimize_control_effort', effort);
 % This problem minimizes the reaction loads on the rotating body at the pin 
 % joint. Specifically, the norm of the reaction forces and moments integrated
 % over the phase is minimized.
-reaction = MocoJointReactionCost();
+reaction = MocoJointReactionGoal();
 reaction.setJointPath('pin');
 runInvertedPendulumProblem('minimize_joint_reaction_loads', reaction);
 

--- a/Moco/Bindings/Java/Matlab/Examples/exampleMocoTrack/exampleMocoTrack.m
+++ b/Moco/Bindings/Java/Matlab/Examples/exampleMocoTrack/exampleMocoTrack.m
@@ -137,6 +137,7 @@ track.setName("muscle_driven_state_tracking");
 % parameters.
 modelProcessor = ModelProcessor("subject_walk_armless.osim");
 modelProcessor.append(ModOpAddExternalLoads("grf_walk.xml"));
+modelProcessor.append(ModOpIgnoreTendonCompliance());
 modelProcessor.append(ModOpReplaceMusclesWithDeGrooteFregly2016());
 % Only valid for DeGrooteFregly2016Muscles.
 modelProcessor.append(ModOpIgnorePassiveFiberForcesDGF());

--- a/Moco/Bindings/Java/Matlab/Examples/exampleSitToStand/exampleSitToStand_answers.m
+++ b/Moco/Bindings/Java/Matlab/Examples/exampleSitToStand/exampleSitToStand_answers.m
@@ -47,7 +47,7 @@ problem.setStateInfo('/jointset/ankle_r/ankle_angle_r/value', ...
 problem.setStateInfoPattern('/jointset/.*/speed', [], 0, 0);
 
 % Part 1d: Add a MocoControlCost to the problem.
-problem.addCost(MocoControlCost('myeffort'));
+problem.addGoal(MocoControlGoal('myeffort'));
 
 % Part 1e: Configure the solver.
 solver = study.initCasADiSolver();
@@ -73,15 +73,15 @@ tableProcessor.append(TabOpLowPassFilter(6));
 % from the predictive problem (via the TableProcessor we just created). 
 % Enable the setAllowUnusedReferences() setting to ignore the controls in
 % the predictive solution.
-tracking = MocoStateTrackingCost();
+tracking = MocoStateTrackingGoal();
 tracking.setName('mytracking');
 tracking.setReference(tableProcessor);
 tracking.setAllowUnusedReferences(true);
-problem.addCost(tracking);
+problem.addGoal(tracking);
 
 % Part 2c: Reduce the control cost weight so it now acts as a regularization 
 % term.
-problem.updCost('myeffort').set_weight(0.001);
+problem.updGoal('myeffort').setWeight(0.001);
 
 % Part 2d: Set the initial guess using the predictive problem solution.
 % Tighten convergence tolerance to ensure smooth controls.
@@ -118,11 +118,12 @@ inverse.setKinematics(tableProcessor);
 inverse.set_initial_time(0);
 inverse.set_final_time(1);
 inverse.set_mesh_interval(0.05);
-inverse.set_tolerance(1e-4);
+inverse.set_convergence_tolerance(1e-4);
+inverse.set_constraint_tolerance(1e-4);
 
 % Allow extra (unused) columns in the kinematics and minimize activations.
 inverse.set_kinematics_allow_extra_columns(true);
-inverse.set_minimize_sum_squared_states(true);
+inverse.set_minimize_sum_squared_activations(true);
 
 % Append additional outputs path for quantities that are calculated
 % post-hoc using the inverse problem solution.

--- a/Moco/Bindings/Python/examples/exampleMocoTrack/exampleMocoTrack.py
+++ b/Moco/Bindings/Python/examples/exampleMocoTrack/exampleMocoTrack.py
@@ -119,6 +119,7 @@ def muscleDrivenStateTracking():
     # parameters.
     modelProcessor = osim.ModelProcessor("subject_walk_armless.osim")
     modelProcessor.append(osim.ModOpAddExternalLoads("grf_walk.xml"))
+    modelProcessor.append(osim.ModOpIgnoreTendonCompliance())
     modelProcessor.append(osim.ModOpReplaceMusclesWithDeGrooteFregly2016())
     # Only valid for DeGrooteFregly2016Muscles.
     modelProcessor.append(osim.ModOpIgnorePassiveFiberForcesDGF())
@@ -156,7 +157,7 @@ def muscleDrivenStateTracking():
     # Get a reference to the MocoControlCost that is added to every MocoTrack
     # problem by default.
     problem = study.updProblem()
-    effort = osim.MocoControlCost.safeDownCast(problem.updCost("control_effort"))
+    effort = osim.MocoControlGoal.safeDownCast(problem.updGoal("control_effort"))
 
     # Put a large weight on the pelvis CoordinateActuators, which act as the
     # residual, or 'hand-of-god', forces which we would like to keep as small

--- a/Moco/Examples/C++/exampleMocoTrack/exampleMocoTrack.cpp
+++ b/Moco/Examples/C++/exampleMocoTrack/exampleMocoTrack.cpp
@@ -126,6 +126,7 @@ void muscleDrivenStateTracking() {
     ModelProcessor modelProcessor =
             ModelProcessor("subject_walk_armless.osim") |
             ModOpAddExternalLoads("grf_walk.xml") |
+            ModOpIgnoreTendonCompliance() |
             ModOpReplaceMusclesWithDeGrooteFregly2016() |
             // Only valid for DeGrooteFregly2016Muscles.
             ModOpIgnorePassiveFiberForcesDGF() |


### PR DESCRIPTION
Fixes issue #481, #519, and:
- fix skeleton visualization for MATLAB exampleMarkerTracking10DOF (though no skeleton may have been the intended behavior, so this could get rolled back)
- various other fixes to get all examples working (except for C++ `exampleTracking`, noted #523)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/526)
<!-- Reviewable:end -->
