### PR TITLE
Fix Plugin and Example CMake files

### DIFF
--- a/Moco/Examples/C++/ExampleCMakeListsToInstall.txt.in
+++ b/Moco/Examples/C++/ExampleCMakeListsToInstall.txt.in
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(Moco_@_example_name@)
+project(OpenSimMoco_@_example_name@)
 
 set(CMAKE_CXX_STANDARD 11)
 
@@ -14,6 +14,6 @@ foreach(exe @_example_executables@)
     # For Windows: make sure DLLs for dependencies are available.
     MocoCopyDLLs(DEP_NAME OpenSimMoco DEP_BIN_DIR "${OpenSimMoco_BIN_DIR}")
     if(WIN32)
-        add_dependencies(${exe} Copy_Moco_DLLs)
+        add_dependencies(${exe} Copy_OpenSimMoco_DLLs)
     endif()
 endforeach()

--- a/Moco/Examples/C++/PluginExampleCMakeListsToInstall.txt.in
+++ b/Moco/Examples/C++/PluginExampleCMakeListsToInstall.txt.in
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(Moco_@_example_name@)
+project(OpenSimMoco_@_example_name@)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/Moco/Examples/C++/PluginExampleCMakeListsToInstall.txt.in
+++ b/Moco/Examples/C++/PluginExampleCMakeListsToInstall.txt.in
@@ -27,5 +27,5 @@ target_link_libraries(example@_example_name@ osim@_example_name@)
 # For Windows: make sure DLLs for dependencies are available.
 MocoCopyDLLs(DEP_NAME OpenSimMoco DEP_BIN_DIR "${OpenSimMoco_BIN_DIR}")
 if(WIN32)
-    add_dependencies(osim@_example_name@ Copy_Moco_DLLs)
+    add_dependencies(osim@_example_name@ Copy_OpenSimMoco_DLLs)
 endif()


### PR DESCRIPTION
Fixes issue #514 
Address this [forum post](https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=1815&t=11308&p=0&start=0&view=&sid=1f2dde9681c7c36334c5b75a93668a62).

### Brief summary of changes
Update calls of `Copy_Moco_DLLs` to `Copy_OpenSimMoco_DLLs` in the plugin and example CMake scripts. I think this is a leftover from when the project name was changed from `Moco` to `OpenSimMoco`. I was able to build exampleMocoCustomEffortGoal after making this change.

### CHANGELOG.md (choose one)

- [ ] updated
- [x] no need to update because...minor fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/553)
<!-- Reviewable:end -->
