### PR TITLE
Fix reading table in report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 0.3.0 (in development)
 ======================
 
+- 2019-12-17: Fix a bug in report.py related to the now nonexistent 
+              STOFileAdapter.read.
+
 0.2.0
 =====
 - 2019-12-12: Added MocoFrameDistanceConstraint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.3.0 (in development)
+======================
+
 0.2.0
 =====
 - 2019-12-12: Added MocoFrameDistanceConstraint.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(OpenSimMoco VERSION 0.2.0)
+project(OpenSimMoco VERSION 0.3.0)
 
 # Version.
 # --------

--- a/Moco/Bindings/Python/report.py
+++ b/Moco/Bindings/Python/report.py
@@ -144,15 +144,15 @@ class Report(object):
                 # a new file to be used for plotting.
                 # TODO: don't write the extra file permanently
                 if file_ext == '.sto' or file_ext == '.mot':
-                    sto_adapter = osim.STOFileAdapter()
-                    ref = sto_adapter.read(ref_file)
+                    ref = osim.TimeSeriesTable(ref_file)
                     if (ref.hasTableMetaDataKey('inDegrees') and 
                             ref.getTableMetaDataAsString('inDegrees') == 'yes'):
                         simbodyEngine = self.model.getSimbodyEngine()
                         simbodyEngine.convertDegreesToRadians(ref)
                         ref_file = ref_file.replace(file_ext, 
                                 '_radians' + file_ext)
-                        sto_adapter.write(ref, ref_file)                        
+                        sto_adapter = osim.STOFileAdapter()
+                        sto_adapter.write(ref, ref_file)
 
                 num_header_rows = 1
                 with open(ref_file) as f:


### PR DESCRIPTION
### Brief summary of changes

This PR fixes a bug in report.py related to our update to OpenSim; STOFileAdapter.read() no longer exists.

This should be merged *after* #558 

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/559)
<!-- Reviewable:end -->
