### PR TITLE
MocoTrack fix: marking --> marker

### DIFF
--- a/Moco/Moco/MocoTrack.cpp
+++ b/Moco/Moco/MocoTrack.cpp
@@ -254,7 +254,7 @@ void MocoTrack::configureMarkerTracking(MocoProblem& problem, Model& model) {
 
     // Add marker tracking cost to the MocoProblem.
     auto* markerTracking = problem.addGoal<MocoMarkerTrackingGoal>(
-            "marking_tracking", get_markers_global_tracking_weight());
+            "marker_tracking", get_markers_global_tracking_weight());
     markerTracking->setMarkersReference(markersRef);
     markerTracking->setAllowUnusedReferences(get_allow_unused_references());
 


### PR DESCRIPTION
### Brief summary of changes
Fix "marking" typo in MocoTrack marker tracking cost name.

### CHANGELOG.md (choose one)

- [ ] updated
- [x] no need to update because...minor fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/571)
<!-- Reviewable:end -->
