### PR TITLE
Fix a minor typo in the source file for the cheat sheet

### DIFF
--- a/Moco/doc/MocoCheatSheet.tex
+++ b/Moco/doc/MocoCheatSheet.tex
@@ -257,7 +257,7 @@ Export the trajectory.
 \begin{lstlisting}[style=Matlab-editor, basicstyle=\mlttfamily\small, linewidth=0.48\textwidth]
 traj.write('mocotrajectory.sto');
 traj.exportToStatesTable()
-traj.exportToStateTrajectory(mocoProblem)
+traj.exportToStatesTrajectory(mocoProblem)
 \end{lstlisting}
 Compare two trajectories.
 \begin{lstlisting}[style=Matlab-editor, basicstyle=\mlttfamily\small, linewidth=0.48\textwidth]


### PR DESCRIPTION
### Brief summary of changes

I fixed a small typo in the cheatsheet LaTeX file. I did not update the PDF.

### CHANGELOG.md (choose one)

- [x] no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/582)
<!-- Reviewable:end -->
