### PR TITLE
Add passive_force_strain_at_one_norm_force property to DGF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 Change Log
 ==========
+
 0.4.0 (in development) 
 ----------------------
+- 2020-01-29: DeGrooteFregly2016Muscle's passive force multiplier now has a
+              stiffness parameter. To support this change, the curve was 
+              tweaked slightly. This may have a minor effect on solutions
+              relying on passive fiber forces. The maximum difference between
+              the new and old passive force-length curves is 0.07 (unitless).
+
 - 2020-01-28: Added a projection setting to MocoFrameDistanceConstraint.
+
 
 0.3.0 
 -----

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
@@ -56,6 +56,7 @@ void DeGrooteFregly2016Muscle::constructProperties() {
     constructProperty_default_normalized_tendon_force(0.5);
     constructProperty_active_force_width_scale(1.0);
     constructProperty_fiber_damping(0.0);
+    constructProperty_passive_fiber_strain_at_one_norm_force(0.6);
     constructProperty_tendon_strain_at_one_norm_force(0.049);
     constructProperty_ignore_passive_fiber_force(false);
     constructProperty_tendon_compliance_dynamics_mode("explicit");
@@ -108,6 +109,12 @@ void DeGrooteFregly2016Muscle::extendFinalizeFromProperties() {
             "%s: fiber_damping must be greater than or equal to zero, "
             "but it is %g.",
             getName().c_str(), get_fiber_damping());
+
+    SimTK_ERRCHK2_ALWAYS(get_passive_fiber_strain_at_one_norm_force() > 0,
+            "DeGrooteFregly2016Muscle::extendFinalizeFromProperties",
+            "%s: passive_fiber_strain_at_one_norm_force must be greater "
+            "than zero, but it is %g.",
+            getName().c_str(), get_passive_fiber_strain_at_one_norm_force());
 
     SimTK_ERRCHK2_ALWAYS(get_tendon_strain_at_one_norm_force() > 0,
             "DeGrooteFregly2016Muscle::extendFinalizeFromProperties",
@@ -911,6 +918,9 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
             actu->set_deactivation_time_constant(
                     musc->get_deactivation_time_constant());
             actu->set_fiber_damping(musc->get_fiber_damping());
+            actu->set_passive_fiber_strain_at_one_norm_force(
+                    musc->get_FiberForceLengthCurve()
+                            .get_strain_at_one_norm_force());
             actu->set_tendon_strain_at_one_norm_force(
                     musc->get_TendonForceLengthCurve()
                             .get_strain_at_one_norm_force());
@@ -925,6 +935,9 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
             // Fiber damping needs to be hardcoded at zero since it is not a
             // property of the Thelen2003 muscle.
             actu->set_fiber_damping(0);
+            actu->set_passive_fiber_strain_at_one_norm_force(
+                    musc->get_FmaxMuscleStrain());
+
             actu->set_tendon_strain_at_one_norm_force(
                     musc->get_FmaxTendonStrain());
 

--- a/Moco/Moco/ModelOperators.h
+++ b/Moco/Moco/ModelOperators.h
@@ -133,6 +133,35 @@ public:
     }
 };
 
+/// Set passive fiber stiffness for all DeGrooteFregly2016Muscle$%s in the
+/// model.
+class OSIMMOCO_API ModOpPassiveFiberStrainAtOneNormForceDGF
+        : public ModelOperator {
+OpenSim_DECLARE_CONCRETE_OBJECT(
+        ModOpPassiveFiberStrainAtOneNormForceDGF, ModelOperator);
+    OpenSim_DECLARE_PROPERTY(passive_fiber_strain_at_one_norm_force, double,
+            "Fiber strain when the passive fiber force is 1 normalized force. "
+            "Default: 0.6.");
+
+public:
+    ModOpPassiveFiberStrainAtOneNormForceDGF() {
+        constructProperty_passive_fiber_strain_at_one_norm_force(0.6);
+    }
+    ModOpPassiveFiberStrainAtOneNormForceDGF(double value) :
+            ModOpPassiveFiberStrainAtOneNormForceDGF() {
+        set_passive_fiber_strain_at_one_norm_force(value);
+    }
+
+    void operate(Model& model, const std::string&) const override {
+        model.finalizeFromProperties();
+        for (auto& muscle :
+                model.updComponentList<DeGrooteFregly2016Muscle>()) {
+            muscle.set_passive_fiber_strain_at_one_norm_force(
+                    get_passive_fiber_strain_at_one_norm_force());
+        }
+    }
+};
+
 /// Scale the active fiber force curve width for all DeGrooteFregly2016Muscle%s
 /// in the model.
 class OSIMMOCO_API ModOpScaleActiveFiberForceCurveWidthDGF :

--- a/Moco/Moco/ModelOperators.h
+++ b/Moco/Moco/ModelOperators.h
@@ -133,7 +133,7 @@ public:
     }
 };
 
-/// Set passive fiber stiffness for all DeGrooteFregly2016Muscle$%s in the
+/// Set passive fiber stiffness for all DeGrooteFregly2016Muscle%s in the
 /// model.
 class OSIMMOCO_API ModOpPassiveFiberStrainAtOneNormForceDGF
         : public ModelOperator {

--- a/Moco/Sandbox/DeGrooteFregly2016MuscleDerivatives.m
+++ b/Moco/Sandbox/DeGrooteFregly2016MuscleDerivatives.m
@@ -1,0 +1,32 @@
+syms b1 b2 b3 b4 lMtilde min_lMtilde c1 c2 c3 lTtilde kT kPE e0
+
+fprintf('Derivative of tendon force length curve \n')
+fprintf('======================================= \n')
+
+f_t = c1*exp(kT*(lTtilde - c2)) - c3;
+simplify(diff(f_t, lTtilde))
+
+fprintf('Derivative of active fiber force length curve \n')
+fprintf('============================================= \n')
+
+f_act = b1 * exp((-0.5*(lMtilde-b2)^2) / ((b3 + b4*lMtilde)^2));
+simplify(diff(f_act, lMtilde))
+
+fprintf('Derivative of passive fiber force length curve \n')
+fprintf('============================================== \n')
+
+f_pas = (exp(kPE * (lMtilde - 1.0) / e0) - exp(kPE * (min_lMtilde - 1) / e0)) / ...
+        (exp(kPE) - exp(kPE * (min_lMtilde - 1) / e0));
+simplify(diff(f_pas, lMtilde))
+
+fprintf('Integral of tendon force length curve \n')
+fprintf('===================================== \n')
+
+f_t = c1*exp(kT*(lTtilde - c2)) - c3;
+simplify(int(f_t, lTtilde))
+
+fprintf('Integral of passive fiber force length curve \n')
+fprintf('============================================ \n')
+
+f_pas_int = simplify(int(f_pas, lMtilde))
+pretty(f_pas_int)

--- a/Moco/Sandbox/sandboxDGFPassive.m
+++ b/Moco/Sandbox/sandboxDGFPassive.m
@@ -27,8 +27,9 @@ fprintf('fn(1 + FmaxStrain): %f\n', passive_new(1 + FmaxStrain));
 
 syms k c x xm;
 y = (exp(k*(x - 1)/c) - exp(k*(xm - 1)/c)) / (exp(k) - exp(k*(xm - 1)/c))
-yint = simplify(int(y))
-simplify(diff(yint, x))
+yint = simplify(int(y));
+pretty(yint)
+pretty(simplify(diff(yint, x)))
 
 end
 

--- a/Moco/Sandbox/sandboxDGFPassive.m
+++ b/Moco/Sandbox/sandboxDGFPassive.m
@@ -1,0 +1,66 @@
+function sandboxDGFPassive
+
+global xmin;
+global FmaxStrain;
+
+xmin = 0.2;
+FmaxStrain = 0.6;
+
+x = linspace(0, 1.8, 1000);
+
+y = passive(x);
+plot(x, y);
+hold on;
+y_new = passive_new(x);
+plot(x, y_new);
+fprintf('max error: %f\n', max(abs(y_new - y)));
+
+legend('old', 'new');
+
+fprintf('f(xmin): %f\n', passive(xmin));
+fprintf('f(1): %f\n', passive(1.0));
+fprintf('f(1 + FmaxStrain): %f\n', passive(1 + FmaxStrain));
+fprintf('\n');
+fprintf('fn(xmin): %f\n', passive_new(xmin));
+fprintf('fn(1): %f\n', passive_new(1.0));
+fprintf('fn(1 + FmaxStrain): %f\n', passive_new(1 + FmaxStrain));
+
+syms k c x xm;
+y = (exp(k*(x - 1)/c) - exp(k*(xm - 1)/c)) / (exp(k) - exp(k*(xm - 1)/c))
+yint = simplify(int(y))
+simplify(diff(yint, x))
+
+end
+
+function y = passive(x)
+
+global xmin;
+global FmaxStrain;
+
+kPE = 4;
+e0 = FmaxStrain;
+
+numer_offset = exp(kPE * (xmin - 1.0) / e0);
+% numer_offset = 1;
+
+denom = exp(kPE) - 1.0;
+y = (exp(kPE * (x - 1.0) / e0) - numer_offset) / denom;
+
+
+end
+
+function y = passive_new(x)
+
+global xmin;
+global FmaxStrain;
+
+kPE = 4;
+e0 = FmaxStrain;
+
+offset = exp(kPE * (xmin - 1.0) / e0);
+
+denom = exp(kPE) - offset;
+y = (exp(kPE * (x - 1.0) / e0) - offset) / denom;
+
+
+end

--- a/Moco/Tests/testMocoActuators.cpp
+++ b/Moco/Tests/testMocoActuators.cpp
@@ -187,14 +187,31 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             REQUIRE_THROWS_AS(musc.finalizeFromProperties(),
                     SimTK::Exception::ErrorCheck);
         }
+        SECTION("passive_fiber_strain_at_one_norm_force") {
+            musc.set_passive_fiber_strain_at_one_norm_force(0);
+            REQUIRE_THROWS_AS(musc.finalizeFromProperties(),
+                    SimTK::Exception::ErrorCheck);
+        }
     }
 
     SECTION("printCurvesToSTOFiles") { muscle.printCurvesToSTOFiles(); }
 
     SECTION("Curve values") {
         CHECK(muscle.calcTendonForceMultiplier(1) == 0);
+
+        CHECK(muscle.calcTendonForceMultiplier(
+                      1 + muscle.get_tendon_strain_at_one_norm_force()) ==
+                Approx(1).epsilon(1e-10));
+
         CHECK(muscle.calcPassiveForceMultiplier(1) ==
-                Approx(0.018567).epsilon(1e-4));
+                Approx(0.0182288).epsilon(1e-4));
+        CHECK(muscle.calcPassiveForceMultiplier(0.2) ==
+                Approx(0).epsilon(1e-4));
+        CHECK(muscle.calcPassiveForceMultiplier(
+                      1 +
+                      muscle.get_passive_fiber_strain_at_one_norm_force()) ==
+                Approx(1).epsilon(1e-4));
+
         CHECK(muscle.calcActiveForceLengthMultiplier(1) == Approx(1));
         CHECK(muscle.calcForceVelocityMultiplier(-1) == 0);
         CHECK(muscle.calcForceVelocityMultiplier(0) == Approx(1));
@@ -814,7 +831,7 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     muscle.calcActiveForceLengthMultiplier(normFiberLength);
 
             CHECK(muscle.getFiberLength(state) == Approx(fiberLength));
-            CHECK(muscle.getNormalizedFiberLength(state) == Approx(0.930485));
+            CHECK(muscle.getNormalizedFiberLength(state) == Approx(0.9305004));
             CHECK(muscle.getPennationAngle(state) == Approx(pennationAngle));
             CHECK(muscle.getCosPennationAngle(state) ==
                     Approx(cosPennationAngle));


### PR DESCRIPTION
Fixes issue #488 

### Brief summary of changes

- This PR alters the passive fiber force curve so that it is easier to parameterize by "strain at one norm force".
- The DGF muscle now has a `passive_fiber_strain_at_one_norm_force` property.
- This new property is carried over when converting from Millard or Thelen muscles.
- I also updated the derivative and integral of this function, relying on MATLAB symbolics.

### Details (optional)

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/588)
<!-- Reviewable:end -->
