### PR TITLE
Fix typo: "implicit auxiliary dynamics"

### DIFF
--- a/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.h
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.h
@@ -151,7 +151,7 @@ public:
             "Default: 1.0.");
     OpenSim_DECLARE_PROPERTY(minimize_implicit_auxiliary_derivatives, bool,
             "Minimize the integral of the squared derivative continuous "
-            "variables for components with implicit multibody dynamics. "
+            "variables for components with implicit auxiliary dynamics. "
             "Default: false.");
     OpenSim_DECLARE_PROPERTY(implicit_auxiliary_derivatives_weight, double,
             "The weight on the cost term added if "


### PR DESCRIPTION
This PR fixes a minor typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/597)
<!-- Reviewable:end -->
