### PR TITLE
Update doxygen equations for MocoControlTrackingGoal and MocoSumSquaredStateGoal

### DIFF
--- a/Moco/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -60,7 +60,8 @@ private:
 ///
 /// \f[
 /// \frac{1}{mg} \int_{t_i}^{t_f}
-///         \sum_{g \in G} \|\mathrm{proj}_{\hat{n}}(F_{m,g} - F_{e,g})\|^2 ~dt
+///         \sum_{j \in G}
+///             \|\mathrm{proj}_{\hat{n}}(\vec{F}_{m,j} - \vec{F}_{e,j})\|^2 ~dt
 /// \f]
 /// We use the following notation:
 /// - \f$ mg \f$: the total weight of the system.
@@ -69,13 +70,13 @@ private:
 /// - \f$ \mathrm{proj}_{\hat{n}}() \f$: this function projects the force error
 ///     either onto \f$ \hat{n} \f$ or onto the plane perpendicular to
 ///     \f$ \hat{n} \f$.
-/// - \f$ F_{m,g} \f$ the sum of the contact forces in group \f$ g \f$,
+/// - \f$ \vec{F}_{m,j} \f$ the sum of the contact forces in group \f$ j \f$,
 ///     expressed in ground.
-/// - \f$ F_{e,g} \f$ the experimental contact force for group \f$ g \f$,
+/// - \f$ \vec{F}_{e,j} \f$ the experimental contact force for group \f$ j \f$,
 ///     expressed in ground.
 ///
-/// If the model's gravity $g$ is 0, then we normalize by the total mass of the
-/// system instead of the total weight.
+/// If the model's gravity \f$ g \f$ is 0, then we normalize by the total mass
+/// of the system instead of the total weight.
 ///
 /// ### Tracking a subset of force components
 ///

--- a/Moco/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -64,7 +64,10 @@ private:
 ///             \|\mathrm{proj}_{\hat{n}}(\vec{F}_{m,j} - \vec{F}_{e,j})\|^2 ~dt
 /// \f]
 /// We use the following notation:
-/// - \f$ mg \f$: the total weight of the system.
+/// - \f$ t_i \f$: the initial time of this phase.
+/// - \f$ t_f \f$: the final time of this phase.
+/// - \f$ mg \f$: the total weight of the system; replaced with
+///     \f$ m \f$ if \f$ g = 0 \f$.
 /// - \f$ G \f$: the set of contact groups.
 /// - \f$ \hat{n} \f$: a vector used for projecting the force error.
 /// - \f$ \mathrm{proj}_{\hat{n}}() \f$: this function projects the force error
@@ -74,9 +77,6 @@ private:
 ///     expressed in ground.
 /// - \f$ \vec{F}_{e,j} \f$ the experimental contact force for group \f$ j \f$,
 ///     expressed in ground.
-///
-/// If the model's gravity \f$ g \f$ is 0, then we normalize by the total mass
-/// of the system instead of the total weight.
 ///
 /// ### Tracking a subset of force components
 ///

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.h
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.h
@@ -32,6 +32,8 @@ namespace OpenSim {
 /// \int_{t_i}^{t_f} \sum_{s \in S} w_s y_s(t)^2 ~dt
 /// \f]
 /// We use the following notation:
+/// - \f$ t_i \f$: the initial time of this phase.
+/// - \f$ t_f \f$: the final time of this phase.
 /// - \f$ S \f$: the set of state variables selected for this goal.
 /// - \f$ w_s \f$: the weight for state variable \f$ s \f$.
 /// - \f$ y_s(t) \f$: state variable \f$ s \f$.

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.h
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.h
@@ -25,9 +25,21 @@ namespace OpenSim {
 
 /// Minimize the sum of squared states, integrated over the phase. For example, 
 /// this can be used to minimize muscle activations, as is done in MocoInverse.
-/// This class also allows you to select which states to minimize by using
-/// a regex pattern with `setPattern()` and to provide weights for each
-/// state through `setWeightSet()` and `setWeightForState()`.
+///
+/// This goal is computed as follows:
+///
+/// \f[
+/// \int_{t_i}^{t_f} \sum_{s \in S} w_s y_s(t)^2 ~dt
+/// \f]
+/// We use the following notation:
+/// - \f$ S \f$: the set of state variables selected for this goal.
+/// - \f$ w_s \f$: the weight for state variable \f$ s \f$.
+/// - \f$ y_s(t) \f$: state variable \f$ s \f$.
+///
+/// Select which states to minimize by using
+/// a regex pattern with `setPattern()`. Provide weights for each
+/// state through `setWeightSet()` or `setWeightForState()`.
+/// @ingroup mocogoal
 class OSIMMOCO_API MocoSumSquaredStateGoal : public MocoGoal {
     OpenSim_DECLARE_CONCRETE_OBJECT(MocoSumSquaredStateGoal, MocoGoal);
 


### PR DESCRIPTION
Part of #333 

### Brief summary of changes

This PR fixes an error with the Doxygen equations for MocoControlTrackingGoal and adds equations for MocoSumSquaredStateGoal.

### CHANGELOG.md (choose one)

- [x] no need to update because...minor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/598)
<!-- Reviewable:end -->
