### PR TITLE
Change URL for ADOL-C.

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -260,7 +260,7 @@ else()
         # automake, libtool?)
         ExternalProject_Add(adolc
             DEPENDS           colpack
-            GIT_REPOSITORY    https://gitlab.com/adol-c/adol-c.git
+            GIT_REPOSITORY    https://gitlab.com/coin-or/ADOL-C.git
             GIT_TAG           v2.6.3
             #SOURCE_DIR        "${CMAKE_SOURCE_DIR}/adol-c"
             #BINARY_DIR        "${CMAKE_SOURCE_DIR}/adol-c"

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -260,7 +260,7 @@ else()
         # automake, libtool?)
         ExternalProject_Add(adolc
             DEPENDS           colpack
-            GIT_REPOSITORY    https://gitlab.com/coin-or/ADOL-C.git
+            GIT_REPOSITORY    https://github.com/coin-or/ADOL-C.git
             GIT_TAG           v2.6.3
             #SOURCE_DIR        "${CMAKE_SOURCE_DIR}/adol-c"
             #BINARY_DIR        "${CMAKE_SOURCE_DIR}/adol-c"

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -261,7 +261,7 @@ else()
         ExternalProject_Add(adolc
             DEPENDS           colpack
             GIT_REPOSITORY    https://github.com/coin-or/ADOL-C.git
-            GIT_TAG           v2.6.3
+            GIT_TAG           releases/2.6.3
             #SOURCE_DIR        "${CMAKE_SOURCE_DIR}/adol-c"
             #BINARY_DIR        "${CMAKE_SOURCE_DIR}/adol-c"
             INSTALL_DIR       "${CMAKE_INSTALL_PREFIX}/adol-c"


### PR DESCRIPTION
Fixes #602 

### Brief summary of changes

ADOL-C moved from GitLab to GitHub; this PR updates our dependencies scripts to account for this move.

Need to wait for CI to build to determine if this is successful.

### CHANGELOG.md (choose one)

- [x] no need to update because...does not affect users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/603)
<!-- Reviewable:end -->
