### PR TITLE
Avoid multiline comment.

### DIFF
--- a/Moco/Examples/C++/example3DWalking/exampleMocoInverse.cpp
+++ b/Moco/Examples/C++/example3DWalking/exampleMocoInverse.cpp
@@ -148,9 +148,9 @@ int main() {
 
     // If you installed the Moco python package, you can compare both solutions
     // using the following command:
-    //      opensim-moco-generate-report subject_walk_armless.osim \
-    //          example3DWalking_MocoInverse_solution.sto --bilateral \
-    //          --ref_files example3DWalking_MocoInverseWithEMG_solution.sto \
+    //      opensim-moco-generate-report subject_walk_armless.osim
+    //          example3DWalking_MocoInverse_solution.sto --bilateral
+    //          --ref_files example3DWalking_MocoInverseWithEMG_solution.sto
     //                      controls_reference.sto
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
### Brief summary of changes

GCC doesn't like multi-line comments, so I got rid of using `\` in a comment.

I ran into this while building a Docker container for the Moco paper.

### CHANGELOG.md (choose one)

- [x] no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/611)
<!-- Reviewable:end -->
