### PR TITLE
[Bindings] Add missing derivative and multiplier commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 0.4.0 (in development) 
 ----------------------
+- 2020-04-03: Added missing MATLAB and Python commands for getting/setting 
+              derivative and multiplier variables to the bindings.
+
 - 2020-03-29: (backwards-incompatible) Updated opensim-core to a version that 
               includes SmoothSphereHalfSpaceForce. Therefore, 
               SmoothSphereHalfSpaceForce was removed from Moco.

--- a/Moco/Bindings/Java/swig/java_moco.i
+++ b/Moco/Bindings/Java/swig/java_moco.i
@@ -372,6 +372,12 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
         for (int i = 0; i < traj.length; ++i) { v.set(i, traj[i]); }
         setMultiplier(name, v);
     }
+    public void setDerivative(String name, double[] traj) {
+        Vector v = new Vector();
+        v.resize(traj.length);
+        for (int i = 0; i < traj.length; ++i) { v.set(i, traj[i]); }
+        setDerivative(name, v);
+    }
     public double[] getTimeMat() {
         Vector time = getTime();
         double[] ret = new double[time.size()];
@@ -396,6 +402,12 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
         for (int i = 0; i < mult.size(); ++i) { ret[i] = mult.get(i); };
         return ret;
     }
+    public double[] getDerivativeMat(String name) {
+        VectorView deriv = getDerivative(name);
+        double[] ret = new double[deriv.size()];
+        for (int i = 0; i < deriv.size(); ++i) { ret[i] = deriv.get(i); };
+        return ret;
+    }
     public double[] getParametersMat() {
         RowVector params = getParameters();
         double[] ret = new double[params.size()];
@@ -415,11 +427,31 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
     public double[][] getControlsTrajectoryMat() {
         Matrix matrix = getControlsTrajectory();
         double[][] ret = new double[matrix.nrow()][matrix.ncol()];
-            for (int i = 0; i < matrix.nrow(); ++i) {
-                for (int j = 0; j < matrix.ncol(); ++j) {
-                    ret[i][j] = matrix.getElt(i, j);
-                }
+        for (int i = 0; i < matrix.nrow(); ++i) {
+            for (int j = 0; j < matrix.ncol(); ++j) {
+                ret[i][j] = matrix.getElt(i, j);
             }
+        }
+        return ret;
+    }
+    public double[][] getMultipliersTrajectoryMat() {
+        Matrix matrix = getMultipliersTrajectory();
+        double[][] ret = new double[matrix.nrow()][matrix.ncol()];
+        for (int i = 0; i < matrix.nrow(); ++i) {
+            for (int j = 0; j < matrix.ncol(); ++j) {
+                ret[i][j] = matrix.getElt(i, j);
+            }
+        }
+        return ret;
+    }
+    public double[][] getDerivativesTrajectoryMat() {
+        Matrix matrix = getDerivativesTrajectory();
+        double[][] ret = new double[matrix.nrow()][matrix.ncol()];
+        for (int i = 0; i < matrix.nrow(); ++i) {
+            for (int j = 0; j < matrix.ncol(); ++j) {
+                ret[i][j] = matrix.getElt(i, j);
+            }
+        }
         return ret;
     }
 %}

--- a/Moco/Bindings/Python/swig/python_moco.i
+++ b/Moco/Bindings/Python/swig/python_moco.i
@@ -281,6 +281,11 @@ using namespace SimTK;
         $self->setMultiplier(name,
                 SimTK::Vector((int)traj.size(), traj.data()));
     }
+    void setDerivative(const std::string& name, const std::vector<double>& traj)
+    {
+        $self->setDerivative(name,
+                SimTK::Vector((int)traj.size(), traj.data()));
+    }
     void _getTimeMat(int n, double* timeOut) const {
         OPENSIM_THROW_IF(n != $self->getNumTimes(), OpenSim::Exception,
                 "n != getNumTimes()");

--- a/Moco/Bindings/Python/tests/test_swig_additional_interface.py
+++ b/Moco/Bindings/Python/tests/test_swig_additional_interface.py
@@ -124,10 +124,11 @@ class TestSwigAddtlInterface(unittest.TestCase):
         st = osim.Matrix(3, 2)
         ct = osim.Matrix(3, 3)
         mt = osim.Matrix(3, 1)
+        dt = osim.Matrix(3, 1)
         p = osim.RowVector(2, 0.0)
         it = osim.MocoTrajectory(time, ['s0', 's1'], ['c0', 'c1', 'c2'],
-                              ['m0'],
-                              ['p0', 'p1'], st, ct, mt, p)
+                              ['m0'], ['d0'],
+                              ['p0', 'p1'], st, ct, mt, dt, p)
         
         it.setTime([15, 25, 35])
         assert(it.getTime().get(0) == 15)
@@ -161,6 +162,12 @@ class TestSwigAddtlInterface(unittest.TestCase):
         assert(m0traj[0] == 326)
         assert(m0traj[1] == 1)
         assert(m0traj[2] == 42)
+
+        it.setDerivative('d0', [-10, 477, 125])
+        d0traj = it.getDerivative('d0')
+        assert(d0traj[0] == -10)
+        assert(d0traj[1] == 477)
+        assert(d0traj[2] == 125)
 
         it.setParameter('p0', 25)
         it.setParameter('p1', 30)


### PR DESCRIPTION
Add missing Java and Python bindings for getting/setting derivatives and multipliers.

Fixes issue reported by @rosshm16 on the user forum.

### Brief summary of changes
Added to Java/Matlab bindings:

- setDerivative()
- getDerivativeMat()
- getMultipliersTrajectoryMat()
- getDerivativesTrajectoryMat()

Added to Python bindings:

- setDerivative()
- Updated tests 

### CHANGELOG.md (choose one)

- [x] updated
- [ ] no need to update because...
