### PR TITLE
Correct typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Change Log
 - 2020-03-15: exampleMocoInverse now employs electromyography data with a 
               MocoControlTrackingGoal.
               
-- 2020-03-15: MocoContactTrackingGoal provides more flexibility when associating
+- 2020-03-15: MocoControlTrackingGoal provides more flexibility when associating
               control signals with reference data.
 
 - 2020-03-10: The default parameters for createPeriodicTrajectory() are fixed


### PR DESCRIPTION
### Brief summary of changes

Fix typo in change log where MocoContactTrackingGoal when MocoControlTrackingGoal should have been used.

### CHANGELOG.md (choose one)

- [x] updated
- [ ] no need to update because...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/619)
<!-- Reviewable:end -->
