### PR TITLE
Add 'negate' property to MocoOutputGoal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Change Log
 
 0.5.0 (in development) 
 ----------------------
+- 2020-05-25: MocoOutputGoal can now negate the value of an output.
+
 - 2020-05-16: Moved ActivationCoordinateActuator from opensim-moco to
               opensim-core.
 

--- a/Moco/Moco/MocoGoal/MocoOutputGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoOutputGoal.cpp
@@ -24,6 +24,7 @@ void MocoOutputGoal::constructProperties() {
     constructProperty_output_path("");
     constructProperty_divide_by_displacement(false);
     constructProperty_divide_by_mass(false);
+    constructProperty_negate(false);
 }
 
 void MocoOutputGoal::initializeOnModelImpl(const Model& output) const {
@@ -45,6 +46,9 @@ void MocoOutputGoal::calcIntegrandImpl(
         const SimTK::State& state, double& integrand) const {
     getModel().getSystem().realize(state, m_output->getDependsOnStage());
     integrand = m_output->getValue(state);
+    if (get_negate()) {
+        integrand *= -1.0;
+    }
 }
 
 void MocoOutputGoal::calcGoalImpl(

--- a/Moco/Moco/MocoGoal/MocoOutputGoal.h
+++ b/Moco/Moco/MocoGoal/MocoOutputGoal.h
@@ -56,6 +56,11 @@ public:
         return get_divide_by_mass();
     }
 
+    /// Set if the output value should be negated (i.e., to maximize rather
+    /// than minimize its value).
+    void setNegate(bool tf) { set_negate(tf); }
+    bool getNegate() const { return get_negate(); }
+
 protected:
     void initializeOnModelImpl(const Model&) const override;
     void calcIntegrandImpl(
@@ -72,6 +77,10 @@ private:
             "false)");
     OpenSim_DECLARE_PROPERTY(divide_by_mass, bool,
             "Divide by the model's total mass (default: false)");
+    OpenSim_DECLARE_PROPERTY(negate, bool,
+            "Negate the output value (i.e., maximize the output) "
+            "(default: false).");
+
     void constructProperties();
 
     mutable SimTK::ReferencePtr<const Output<double>> m_output;


### PR DESCRIPTION
Fixes issue #606

### Brief summary of changes

Add a property `negate` to `MocoOutputGoal`.

@aaronsfox does this work for you? Would you want this ability to be on the base `MocoGoal`?

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/637)
<!-- Reviewable:end -->
