### PR TITLE
Do not plot in python example during ctest.

### DIFF
--- a/Moco/Bindings/Python/examples/exampleKinematicConstraints.py
+++ b/Moco/Bindings/Python/examples/exampleKinematicConstraints.py
@@ -36,6 +36,7 @@
 # This example is related to an explanation of kinematic constraints in the
 # appendix of the Moco paper.
 
+import os
 import opensim as osim
 import numpy as np
 
@@ -95,15 +96,16 @@ solution = study.solve()
 
 # If matplotlib is installed, plot the trajectory of the mass and the
 # constraint force applied to the mass throughout the motion.
-has_pylab = False
-try:
-    import pylab as pl
-    from scipy.interpolate import InterpolatedUnivariateSpline
-    has_pylab = True
-except:
-    print('Skipping plotting')
+plot = False
+if os.getenv('OPENSIM_USE_VISUALIZER') != '0':
+    try:
+        import pylab as pl
+        from scipy.interpolate import InterpolatedUnivariateSpline
+        plot = True
+    except:
+        print('Skipping plotting')
 
-if has_pylab:
+if plot:
 
     # Create a figure.
     fig = pl.figure()


### PR DESCRIPTION
### Brief summary of changes

This PR fixes an issue with `exampleKinematicConstraints.py`, where the example would generate a plot during automated testing.

### CHANGELOG.md (choose one)

- [x] no need to update because...new example has not been released yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/641)
<!-- Reviewable:end -->
