### PR TITLE
Use spdlog and fmt::format()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Change Log
 
 0.5.0 (in development) 
 ----------------------
+- 2020-06-08: Moco uses OpenSim's new message logging system.
+
 - 2020-05-24: Expose MocoAccelerationTrackingGoal in Matlab and Python.
 
 - 2020-05-16: Moved ActivationCoordinateActuator from opensim-moco to

--- a/Moco/Examples/C++/exampleCustomImplicitAuxiliaryDynamics/exampleCustomImplicitAuxiliaryDynamics.cpp
+++ b/Moco/Examples/C++/exampleCustomImplicitAuxiliaryDynamics/exampleCustomImplicitAuxiliaryDynamics.cpp
@@ -97,8 +97,8 @@ private:
         OPENSIM_THROW_IF_FRMOBJ(get_foo_dynamics_mode() != "implicit" &&
                                         get_foo_dynamics_mode() != "explicit",
                 Exception,
-                format("Expected foo_dynamics_mode to be 'implicit' or "
-                       "'explicit', but got '%s'.",
+                fmt::format("Expected foo_dynamics_mode to be 'implicit' or "
+                            "'explicit', but got '{}'.",
                         get_foo_dynamics_mode()));
         m_foo_dynamics_mode_implicit = get_foo_dynamics_mode() == "implicit";
     }

--- a/Moco/Executable/opensim-moco.cpp
+++ b/Moco/Executable/opensim-moco.cpp
@@ -58,16 +58,17 @@ void run_tool(std::string setupFile, bool visualize) {
     auto obj = std::unique_ptr<Object>(Object::makeObjectFromFile(setupFile));
 
     OPENSIM_THROW_IF(obj == nullptr, Exception,
-            format("A problem occurred when trying to load file '%s'.",
+            fmt::format("A problem occurred when trying to load file '{}'.",
                     setupFile));
 
     if (const auto* moco = dynamic_cast<const MocoStudy*>(obj.get())) {
         auto solution = moco->solve();
         if (visualize) moco->visualize(solution);
     } else {
-        throw Exception("The provided file '" + setupFile + "' yields a '" +
-                        obj->getConcreteClassName() +
-                        "' but a MocoStudy was expected.");
+        throw Exception(
+                fmt::format("The provided file '{}' yields a '{}' but a "
+                            "MocoStudy was expected.",
+                        setupFile, obj->getConcreteClassName()));
     }
 }
 
@@ -141,8 +142,8 @@ int main(int argc, char* argv[]) {
 
             std::string arg2(argv[2 + offset]);
             OPENSIM_THROW_IF(argc == 4 && arg2 != "--visualize", Exception,
-                    format("Unrecognized option '%s'; did you mean "
-                           "'--visualize'?",
+                    fmt::format("Unrecognized option '{}'; did you mean "
+                                "'--visualize'?",
                             arg2));
             std::string setupFile;
             bool visualize = false;

--- a/Moco/Moco/About.cpp
+++ b/Moco/Moco/About.cpp
@@ -22,8 +22,9 @@
 
 #include "About.h"
 
-#include "MocoUtilities.h"
 #include <stdio.h>
+
+#include <OpenSim/Common/Logger.h>
 
 #define STR(var) #var
 #define MAKE_VERSION_STRING(maj, min, build) STR(maj.min.build)
@@ -44,8 +45,8 @@ namespace OpenSim {
 static const char* OpenSimMocoVersion = GET_OPENSIM_MOCO_VERSION_STRING;
 
 std::string GetMocoVersionAndDate() {
-    return format("version %s, build date %s %s", OpenSimMocoVersion, __TIME__,
-            __DATE__);
+    return fmt::format("version {}, build date {} {}", OpenSimMocoVersion,
+            __TIME__, __DATE__);
 }
 
 std::string GetMocoVersion() { return OpenSimMocoVersion; }

--- a/Moco/Moco/Common/TableProcessor.h
+++ b/Moco/Moco/Common/TableProcessor.h
@@ -163,8 +163,8 @@ public:
             const override {
         if (get_cutoff_frequency() != -1) {
             OPENSIM_THROW_IF(get_cutoff_frequency() <= 0, Exception,
-                    format("Expected cutoff frequency to be positive, "
-                           "but got %f.",
+                    fmt::format("Expected cutoff frequency to be positive, "
+                                "but got {}.",
                             get_cutoff_frequency()));
 
             table = filterLowpass(table, get_cutoff_frequency(), true);

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
@@ -462,10 +462,10 @@ void DeGrooteFregly2016Muscle::calcMuscleLengthInfo(
     calcMuscleLengthInfoHelper(muscleTendonLength,
             get_ignore_tendon_compliance(), mli, normTendonForce);
 
-    if (mli.tendonLength < get_tendon_slack_length() && getDebugLevel() > 0) {
+    if (mli.tendonLength < get_tendon_slack_length()) {
         // TODO the Millard model sets fiber velocity to zero when the
         //       tendon is buckling, but this may create a discontinuity.
-        log_warn("DeGrooteFregly2016Muscle '{}' is buckling (length < "
+        log_info("DeGrooteFregly2016Muscle '{}' is buckling (length < "
                  "tendon_slack_length) at time {} s.",
                 getName(), s.getTime());
     }
@@ -492,8 +492,8 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfo(
             get_ignore_tendon_compliance(), m_isTendonDynamicsExplicit, mli,
             fvi, normTendonForce, normTendonForceDerivative);
 
-    if (fvi.normFiberVelocity < -1.0 && getDebugLevel() > 0) {
-        log_warn("DeGrooteFregly2016Muscle '{}' is exceeding maximum "
+    if (fvi.normFiberVelocity < -1.0) {
+        log_info("DeGrooteFregly2016Muscle '{}' is exceeding maximum "
                  "contraction velocity at time {} s.",
                 getName(), s.getTime());
     }

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
@@ -465,9 +465,9 @@ void DeGrooteFregly2016Muscle::calcMuscleLengthInfo(
     if (mli.tendonLength < get_tendon_slack_length() && getDebugLevel() > 0) {
         // TODO the Millard model sets fiber velocity to zero when the
         //       tendon is buckling, but this may create a discontinuity.
-        std::cout << "Warning: DeGrooteFregly2016Muscle '" << getName()
-                  << "' is buckling (length < tendon_slack_length) at time "
-                  << s.getTime() << " s." << std::endl;
+        log_warn("DeGrooteFregly2016Muscle '{}' is buckling (length < "
+                 "tendon_slack_length) at time {} s.",
+                getName(), s.getTime());
     }
 }
 
@@ -493,9 +493,9 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfo(
             fvi, normTendonForce, normTendonForceDerivative);
 
     if (fvi.normFiberVelocity < -1.0 && getDebugLevel() > 0) {
-        std::cout << "Warning: DeGrooteFregly2016Muscle '" << getName()
-                << "' is exceeding maximum contraction velocity at time "
-                << s.getTime() << " s." << std::endl;
+        log_warn("DeGrooteFregly2016Muscle '{}' is exceeding maximum "
+                 "contraction velocity at time {} s.",
+                getName(), s.getTime());
     }
 }
 
@@ -982,8 +982,8 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
 
         } else {
             OPENSIM_THROW_IF(!allowUnsupportedMuscles, Exception,
-                    format("Muscle '%s' of type %s is unsupported and "
-                           "allowUnsupportedMuscles=false.",
+                    fmt::format("Muscle '{}' of type {} is unsupported and "
+                                "allowUnsupportedMuscles=false.",
                             muscBase.getName(),
                             muscBase.getConcreteClassName()));
             continue;
@@ -1043,12 +1043,12 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
     for (const auto* musc : musclesToDelete) {
         int index = model.getForceSet().getIndex(musc, 0);
         OPENSIM_THROW_IF(index == -1, Exception,
-                format("Muscle with name %s not found in ForceSet.",
+                fmt::format("Muscle with name {} not found in ForceSet.",
                         musc->getName()));
         bool success = model.updForceSet().remove(index);
         OPENSIM_THROW_IF(!success, Exception,
-                format("Attempt to remove muscle with "
-                       "name %s was unsuccessful.",
+                fmt::format("Attempt to remove muscle with "
+                            "name {} was unsuccessful.",
                         musc->getName()));
     }
 

--- a/Moco/Moco/Components/ModelFactory.cpp
+++ b/Moco/Moco/Components/ModelFactory.cpp
@@ -195,13 +195,13 @@ void ModelFactory::replaceMusclesWithPathActuators(OpenSim::Model &model) {
     for (const auto* musc : musclesToDelete) {
         int index = model.getForceSet().getIndex(musc, 0);
         OPENSIM_THROW_IF(index == -1, Exception,
-                         format("Muscle with name %s not found in ForceSet.",
-                                musc->getName()));
+                fmt::format("Muscle with name {} not found in ForceSet.",
+                        musc->getName()));
         bool success = model.updForceSet().remove(index);
         OPENSIM_THROW_IF(!success, Exception,
-                         format("Attempt to remove muscle with "
-                                "name %s was unsuccessful.",
-                                musc->getName()));
+                fmt::format("Attempt to remove muscle with "
+                            "name {} was unsuccessful.",
+                        musc->getName()));
     }
 }
 
@@ -259,8 +259,8 @@ void ModelFactory::removeMuscles(Model& model) {
     for (const auto* musc : musclesToDelete) {
         int index = model.getForceSet().getIndex(musc, 0);
         OPENSIM_THROW_IF(index == -1, Exception,
-                         format("Muscle with name %s not found in ForceSet.",
-                                musc->getName()));
+                fmt::format("Muscle with name {} not found in ForceSet.",
+                        musc->getName()));
         model.updForceSet().remove(index);
     }
 }
@@ -269,12 +269,12 @@ void ModelFactory::createReserveActuators(Model& model, double optimalForce,
         double bound,
         bool skipCoordinatesWithExistingActuators) {
     OPENSIM_THROW_IF(optimalForce <= 0, Exception,
-            format("Invalid value (%g) for create_reserve_actuators; "
+            fmt::format("Invalid value ({}) for create_reserve_actuators; "
                    "should be -1 or positive.",
                     optimalForce));
 
-    std::cout << "Adding reserve actuators with an optimal force of "
-              << optimalForce << "..." << std::endl;
+    log_info("Adding reserve actuators with an optimal force of {}...",
+            optimalForce);
 
     Model modelCopy(model);
     auto state = modelCopy.initSystem();
@@ -306,7 +306,7 @@ void ModelFactory::createReserveActuators(Model& model, double optimalForce,
             actu->setOptimalForce(optimalForce);
             if (!SimTK::isNaN(bound)) {
                 OPENSIM_THROW_IF(bound < 0, Exception,
-                        format("Expected a non-negative bound but got %d.",
+                        fmt::format("Expected a non-negative bound but got {}.",
                                 bound));
                 actu->setMinControl(-bound);
                 actu->setMaxControl(bound);
@@ -316,12 +316,10 @@ void ModelFactory::createReserveActuators(Model& model, double optimalForce,
     }
     // Re-make the system, since there are new actuators.
     model.initSystem();
-    std::cout << "Added " << coordPaths.size()
-              << " reserve actuator(s), "
-                 "for each of the following coordinates:"
-              << std::endl;
+    log_info("Added {} reserve actuator(s), for each of the following "
+             "coordinates:", coordPaths.size());
     for (const auto& name : coordPaths) {
-        std::cout << "  " << name << std::endl;
+        log_info("  {}", name);
     }
 }
 

--- a/Moco/Moco/Components/MultivariatePolynomialFunction.h
+++ b/Moco/Moco/Components/MultivariatePolynomialFunction.h
@@ -62,8 +62,8 @@ public:
     SimTKMultivariatePolynomial(const SimTK::Vector_<T>& coefficients,
             const int& dimension, const int& order) :
             coefficients(coefficients), dimension(dimension), order(order) {
-        OPENSIM_THROW_IF(dimension < 0 || dimension > 4, Exception, format(
-                "Expected dimension >= 0 && <=4 but got %i.", dimension));
+        OPENSIM_THROW_IF(dimension < 0 || dimension > 4, Exception, fmt::format(
+                "Expected dimension >= 0 && <=4 but got {}.", dimension));
         std::array<int, 4> nq {{0, 0, 0, 0}};
         int coeff_nr = 0;
         for (nq[0] = 0; nq[0] < order + 1; ++nq[0]) {
@@ -85,9 +85,8 @@ public:
             }
         }
         OPENSIM_THROW_IF(coefficients.size() != coeff_nr, Exception,
-                format("Expected %i coefficients but got %i.",
-                        coeff_nr, coefficients.size()));
-
+                fmt::format("Expected {} coefficients but got {}.", coeff_nr,
+                        coefficients.size()));
     }
     T calcValue(const SimTK::Vector& x) const override {
         std::array<int, 4> nq {{0, 0, 0, 0}};

--- a/Moco/Moco/Components/PositionMotion.cpp
+++ b/Moco/Moco/Components/PositionMotion.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<PositionMotion> PositionMotion::createFromTable(
             OPENSIM_THROW_IF(!model.findComponent<Component>(coordPath) &&
                                      !allowExtraColumns,
                     Exception,
-                    format("Column '%s' is not a coordinate.", label));
+                    fmt::format("Column '{}' is not a coordinate.", label));
         }
     }
     return posmot;
@@ -193,7 +193,7 @@ void PositionMotion::extendRealizeTopology(SimTK::State& state) const {
     for (const auto& coord : coords) {
         const auto& path = coord.getAbsolutePathString();
         OPENSIM_THROW_IF(!get_functions().contains(path), Exception,
-                format("No function provided for coordinate '%s'.", path));
+                fmt::format("No function provided for coordinate '{}'.", path));
     }
 
     // Create a mapping from SimTK position DOFs to OpenSim Coordinates.

--- a/Moco/Moco/Components/StationPlaneContactForce.cpp
+++ b/Moco/Moco/Components/StationPlaneContactForce.cpp
@@ -37,7 +37,6 @@ void StationPlaneContactForce::generateDecorations(
         const auto& pt = getConnectee<Station>("station");
         const auto pt1 = pt.getLocationInGround(s);
         const SimTK::Vec3 force = calcContactForceOnStation(s);
-        // std::cout << "DEBUGgd force " << force << std::endl;
         const SimTK::Vec3 pt2 = pt1 + force * arrowLengthPerForce; // mg;
         SimTK::DecorativeLine line(pt1, pt2);
         line.setColor(SimTK::Green);

--- a/Moco/Moco/MocoBounds.cpp
+++ b/Moco/Moco/MocoBounds.cpp
@@ -36,7 +36,7 @@ MocoBounds::MocoBounds(double lower, double upper) : MocoBounds() {
     OPENSIM_THROW_IF(SimTK::isNaN(lower) || SimTK::isNaN(upper), Exception, 
         "NaN value detected. Please provide a non-NaN values for the bounds.");
     OPENSIM_THROW_IF(lower > upper, Exception,
-        format("Expected lower <= upper, but lower=%g and upper=%g.",
+        fmt::format("Expected lower <= upper, but lower={} and upper={}.",
                 lower, upper));
     append_bounds(lower);
     append_bounds(upper);

--- a/Moco/Moco/MocoBounds.cpp
+++ b/Moco/Moco/MocoBounds.cpp
@@ -60,12 +60,5 @@ void MocoBounds::constructProperties() {
     constructProperty_bounds();
 }
 
-void MocoBounds::printDescription(std::ostream& stream) const {
-    if (isEquality()) {
-        stream << getLower();
-    }
-    else {
-        stream << "[" << getLower() << ", " << getUpper() << "]";
-    }
-    stream.flush();
-}
+
+

--- a/Moco/Moco/MocoBounds.h
+++ b/Moco/Moco/MocoBounds.h
@@ -87,8 +87,6 @@ public:
         return vec;
     }
 
-    void printDescription(std::ostream& stream) const;
-
 protected:
     /// Used internally to create Bounds from a list property.
     /// The list property must have either 0, 1 or 2 elements.
@@ -106,6 +104,17 @@ private:
     void constructProperties();
 
 };
+
+inline std::ostream& operator<<(
+        std::ostream& stream, const MocoBounds& bounds) {
+    if (bounds.isEquality()) {
+        stream << bounds.getLower();
+    } else {
+        stream << "[" << bounds.getLower() << ", " << bounds.getUpper() << "]";
+    }
+    return stream;
+}
+
 /// Used for specifying the bounds on a variable at the start of a phase.
 class OSIMMOCO_API MocoInitialBounds : public MocoBounds {
 OpenSim_DECLARE_CONCRETE_OBJECT(MocoInitialBounds, MocoBounds);

--- a/Moco/Moco/MocoCasADiSolver/CasOCProblem.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCProblem.cpp
@@ -28,7 +28,6 @@
 #include "MocoCasOCProblem.h"
 
 using OpenSim::Exception;
-using OpenSim::format;
 
 namespace CasOC {
 
@@ -43,7 +42,7 @@ std::vector<std::string>
 Problem::createKinematicConstraintEquationNamesImpl() const {
     std::vector<std::string> names(getNumKinematicConstraintEquations());
     for (int i = 0; i < getNumKinematicConstraintEquations(); ++i) {
-        names[i] = format("kinematic_constraint_%03i", i);
+        names[i] = fmt::format("kinematic_constraint_{:03i}", i);
     }
     return names;
 }

--- a/Moco/Moco/MocoCasADiSolver/CasOCSolver.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCSolver.cpp
@@ -22,7 +22,6 @@
 #include "CasOCTrapezoidal.h"
 
 using OpenSim::Exception;
-using OpenSim::format;
 
 namespace CasOC {
 
@@ -33,8 +32,9 @@ std::unique_ptr<Transcription> Solver::createTranscription() const {
     } else if (m_transcriptionScheme == "hermite-simpson") {
         transcription = OpenSim::make_unique<HermiteSimpson>(*this, m_problem);
     } else {
-        OPENSIM_THROW(Exception, format("Unknown transcription scheme '%s'.",
-                                         m_transcriptionScheme));
+        OPENSIM_THROW(
+                Exception, fmt::format("Unknown transcription scheme '{}'.",
+                                   m_transcriptionScheme));
     }
     return transcription;
 }
@@ -64,8 +64,7 @@ void Solver::setSparsityDetectionRandomCount(int count) {
 void Solver::setParallelism(std::string parallelism, int numThreads) {
     m_parallelism = parallelism;
     OPENSIM_THROW_IF(numThreads < 1, OpenSim::Exception,
-            OpenSim::format(
-                    "Expected numThreads >= 1 but got %i.", numThreads));
+            fmt::format("Expected numThreads >= 1 but got {}.", numThreads));
     m_numThreads = numThreads;
 }
 

--- a/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -622,8 +622,8 @@ Solution Transcription::solve(const Iterate& guessOrig) {
         // were removed.
         OPENSIM_THROW_IF(slacks.size2() != m_numMeshInteriorPoints,
                 OpenSim::Exception,
-                OpenSim::format("Expected slack variables to be length %i, "
-                                "but they are length %i.",
+                fmt::format("Expected slack variables to be length {}, "
+                            "but they are length {}.",
                         m_numMeshInteriorPoints, slacks.size2()));
     }
 
@@ -706,7 +706,6 @@ Solution Transcription::solve(const Iterate& guessOrig) {
     solution.stats = nlpFunc.stats();
 
     // Print breakdown of objective.
-    std::cout << "\n";
     printObjectiveBreakdown(solution, objectiveOut[0]);
 
     if (!solution.stats.at("success")) {
@@ -1067,8 +1066,7 @@ void Transcription::printConstraintValues(const Iterate& it,
                     const double L1 = max;
                     const double time_of_max = it.times(argmax).scalar();
 
-                    std::string label =
-                            OpenSim::format("%s_%02i", pc.name, ieq);
+                    std::string label = fmt::format("{}_{:02i}", pc.name, ieq);
                     std::cout << std::setfill('0') << std::setw(2) << ipc << ":"
                               << std::setfill(' ') << std::setw(maxNameLength)
                               << label << spacer << std::setprecision(2)

--- a/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -724,8 +724,7 @@ void Transcription::printConstraintValues(const Iterate& it,
         const Constraints<casadi::DM>& constraints,
         std::ostream& stream) const {
 
-    // We want to be able to restore the stream's original formatting.
-    OpenSim::StreamFormat streamFormat(stream);
+    std::stringstream ss;
 
     // Find the longest state, control, multiplier, derivative, or slack name.
     auto compareSize = [](const std::string& a, const std::string& b) {
@@ -746,21 +745,21 @@ void Transcription::printConstraintValues(const Iterate& it,
     updateMaxNameLength(it.derivative_names);
     updateMaxNameLength(it.slack_names);
 
-    stream << "\nActive or violated continuous variable bounds" << std::endl;
-    stream << "L and U indicate which bound is active; "
+    ss << "\nActive or violated continuous variable bounds" << std::endl;
+    ss << "L and U indicate which bound is active; "
               "'*' indicates a bound is violated. "
            << std::endl;
-    stream << "The case of lower==upper==value is ignored." << std::endl;
+    ss << "The case of lower==upper==value is ignored." << std::endl;
 
     // Bounds on time-varying variables.
     // ---------------------------------
-    auto print_bounds = [&stream, maxNameLength](const std::string& description,
+    auto print_bounds = [&ss, maxNameLength](const std::string& description,
                                 const std::vector<std::string>& names,
                                 const casadi::DM& times,
                                 const casadi::DM& values,
                                 const casadi::DM& lower,
                                 const casadi::DM& upper) {
-        stream << "\n" << description << ": ";
+        ss << "\n" << description << ": ";
 
         bool boundsActive = false;
         bool boundsViolated = false;
@@ -781,17 +780,17 @@ void Transcription::printConstraintValues(const Iterate& it,
         }
 
         if (!boundsActive && !boundsViolated) {
-            stream << "no bounds active or violated" << std::endl;
+            ss << "no bounds active or violated" << std::endl;
             return;
         }
 
         if (!boundsViolated) {
-            stream << "some bounds active but no bounds violated";
+            ss << "some bounds active but no bounds violated";
         } else {
-            stream << "some bounds active or violated";
+            ss << "some bounds active or violated";
         }
 
-        stream << "\n"
+        ss << "\n"
                << std::setw(maxNameLength) << "  " << std::setw(9) << "time "
                << "  " << std::setw(9) << "lower"
                << "    " << std::setw(9) << "value"
@@ -808,22 +807,22 @@ void Transcription::printConstraintValues(const Iterate& it,
                     // issue; ignore.
                     if (V == L && L == U) continue;
                     const auto& time = times(itime);
-                    stream << std::setw(maxNameLength) << names[ivar] << "  "
+                    ss << std::setw(maxNameLength) << names[ivar] << "  "
                            << std::setprecision(2) << std::scientific
                            << std::setw(9) << time << "  " << std::setw(9) << L
                            << " <= " << std::setw(9) << V
                            << " <= " << std::setw(9) << U << " ";
                     // Show if the constraint is violated.
                     if (V <= L)
-                        stream << "L";
+                        ss << "L";
                     else
-                        stream << " ";
+                        ss << " ";
                     if (V >= U)
-                        stream << "U";
+                        ss << "U";
                     else
-                        stream << " ";
-                    if (V < L || V > U) stream << "*";
-                    stream << std::endl;
+                        ss << " ";
+                    if (V < L || V > U) ss << "*";
+                    ss << std::endl;
                 }
             }
         }
@@ -850,19 +849,19 @@ void Transcription::printConstraintValues(const Iterate& it,
     std::vector<std::string> time_names = {"initial_time", "final_time"};
     updateMaxNameLength(time_names);
 
-    stream << "\nActive or violated parameter bounds" << std::endl;
-    stream << "L and U indicate which bound is active; "
+    ss << "\nActive or violated parameter bounds" << std::endl;
+    ss << "L and U indicate which bound is active; "
               "'*' indicates a bound is violated. "
            << std::endl;
-    stream << "The case of lower==upper==value is ignored." << std::endl;
+    ss << "The case of lower==upper==value is ignored." << std::endl;
 
-    auto printParameterBounds = [&stream, maxNameLength](
+    auto printParameterBounds = [&ss, maxNameLength](
                                         const std::string& description,
                                         const std::vector<std::string>& names,
                                         const casadi::DM& values,
                                         const casadi::DM& lower,
                                         const casadi::DM& upper) {
-        stream << "\n" << description << ": ";
+        ss << "\n" << description << ": ";
 
         bool boundsActive = false;
         bool boundsViolated = false;
@@ -881,17 +880,17 @@ void Transcription::printConstraintValues(const Iterate& it,
         }
 
         if (!boundsActive && !boundsViolated) {
-            stream << "no bounds active or violated" << std::endl;
+            ss << "no bounds active or violated" << std::endl;
             return;
         }
 
         if (!boundsViolated) {
-            stream << "some bounds active but no bounds violated";
+            ss << "some bounds active but no bounds violated";
         } else {
-            stream << "some bounds active or violated";
+            ss << "some bounds active or violated";
         }
 
-        stream << "\n"
+        ss << "\n"
                << std::setw(maxNameLength) << "  " << std::setw(9) << "lower"
                << "    " << std::setw(9) << "value"
                << "    " << std::setw(9) << "upper"
@@ -905,21 +904,21 @@ void Transcription::printConstraintValues(const Iterate& it,
                 // In the case where lower==upper==value, there is no
                 // issue; ignore.
                 if (V == L && L == U) continue;
-                stream << std::setw(maxNameLength) << names[ivar] << "  "
+                ss << std::setw(maxNameLength) << names[ivar] << "  "
                        << std::setprecision(2) << std::scientific
                        << std::setw(9) << L << " <= " << std::setw(9) << V
                        << " <= " << std::setw(9) << U << " ";
                 // Show if the constraint is violated.
                 if (V <= L)
-                    stream << "L";
+                    ss << "L";
                 else
-                    stream << " ";
+                    ss << " ";
                 if (V >= U)
-                    stream << "U";
+                    ss << "U";
                 else
-                    stream << " ";
-                if (V < L || V > U) stream << "*";
-                stream << std::endl;
+                    ss << " ";
+                if (V < L || V > U) ss << "*";
+                ss << std::endl;
             }
         }
     };
@@ -942,12 +941,12 @@ void Transcription::printConstraintValues(const Iterate& it,
 
     // Constraints.
     // ============
-    stream << "\nTotal number of constraints: " << m_numConstraints << "."
+    ss << "\nTotal number of constraints: " << m_numConstraints << "."
            << std::endl;
 
     // Differential equation defects.
     // ------------------------------
-    stream << "\nDifferential equation defects:"
+    ss << "\nDifferential equation defects:"
            << "\n  L2 norm across mesh, max abs value (L1 norm), time of max "
               "abs"
            << std::endl;
@@ -974,7 +973,7 @@ void Transcription::printConstraintValues(const Iterate& it,
         const double L1 = max;
         const double time_of_max = it.times(argmax).scalar();
 
-        stream << std::setw(maxNameLength) << it.state_names[istate] << spacer
+        ss << std::setw(maxNameLength) << it.state_names[istate] << spacer
                << std::setprecision(2) << std::scientific << std::setw(9) << L2
                << spacer << L1 << spacer << std::setprecision(6) << std::fixed
                << time_of_max << std::endl;
@@ -982,15 +981,15 @@ void Transcription::printConstraintValues(const Iterate& it,
 
     // Kinematic constraints.
     // ----------------------
-    stream << "\nKinematic constraints:";
+    ss << "\nKinematic constraints:";
     std::vector<std::string> kinconNames =
             m_problem.createKinematicConstraintEquationNames();
     if (kinconNames.empty()) {
-        stream << " none" << std::endl;
+        ss << " none" << std::endl;
     } else {
         maxNameLength = 0;
         updateMaxNameLength(kinconNames);
-        stream << "\n  L2 norm across mesh, max abs value (L1 norm), time of "
+        ss << "\n  L2 norm across mesh, max abs value (L1 norm), time of "
                   "max "
                   "abs"
                << std::endl;
@@ -1005,54 +1004,53 @@ void Transcription::printConstraintValues(const Iterate& it,
                 const double time_of_max = it.times(argmax).scalar();
 
                 std::string label = kinconNames.at(ikc);
-                std::cout << std::setfill('0') << std::setw(2) << ikc << ":"
-                          << std::setfill(' ') << std::setw(maxNameLength)
-                          << label << spacer << std::setprecision(2)
-                          << std::scientific << std::setw(9) << L2 << spacer
-                          << L1 << spacer << std::setprecision(6) << std::fixed
-                          << time_of_max << std::endl;
+                ss << std::setfill('0') << std::setw(2) << ikc << ":"
+                       << std::setfill(' ') << std::setw(maxNameLength) << label
+                       << spacer << std::setprecision(2) << std::scientific
+                       << std::setw(9) << L2 << spacer << L1 << spacer
+                       << std::setprecision(6) << std::fixed << time_of_max
+                       << std::endl;
             }
         }
-        stream << "Kinematic constraint values at each mesh point:"
+        ss << "Kinematic constraint values at each mesh point:"
                << std::endl;
-        stream << "      time  ";
+        ss << "      time  ";
         for (int ipc = 0; ipc < (int)kinconNames.size(); ++ipc) {
-            stream << std::setw(9) << ipc << "  ";
+            ss << std::setw(9) << ipc << "  ";
         }
-        stream << std::endl;
+        ss << std::endl;
         for (int imesh = 0; imesh < m_numMeshPoints; ++imesh) {
-            stream << std::setfill('0') << std::setw(3) << imesh << "  ";
-            stream.fill(' ');
-            stream << std::setw(9) << it.times(imesh).scalar() << "  ";
+            ss << std::setfill('0') << std::setw(3) << imesh << "  ";
+            ss.fill(' ');
+            ss << std::setw(9) << it.times(imesh).scalar() << "  ";
             for (int ikc = 0; ikc < (int)kinconNames.size(); ++ikc) {
                 const auto& value = constraints.kinematic(ikc, imesh).scalar();
-                stream << std::setprecision(2) << std::scientific
+                ss << std::setprecision(2) << std::scientific
                        << std::setw(9) << value << "  ";
             }
-            stream << std::endl;
+            ss << std::endl;
         }
     }
 
     // Path constraints.
     // -----------------
-    stream << "\nPath constraints:";
+    ss << "\nPath constraints:";
     std::vector<std::string> pathconNames;
     for (const auto& pc : m_problem.getPathConstraintInfos()) {
         pathconNames.push_back(pc.name);
     }
 
     if (pathconNames.empty()) {
-        stream << " none" << std::endl;
+        ss << " none" << std::endl;
     } else {
-        stream << std::endl;
+        ss << std::endl;
 
         maxNameLength = 0;
         updateMaxNameLength(pathconNames);
         // To make space for indices.
         maxNameLength += 3;
-        stream << "\n  L2 norm across mesh, max abs value (L1 norm), time of "
-                  "max "
-                  "abs"
+        ss << "\n  L2 norm across mesh, max abs value (L1 norm), time of "
+                  "max abs"
                << std::endl;
         row.resize(1, m_numMeshPoints);
         {
@@ -1067,50 +1065,59 @@ void Transcription::printConstraintValues(const Iterate& it,
                     const double time_of_max = it.times(argmax).scalar();
 
                     std::string label = fmt::format("{}_{:02i}", pc.name, ieq);
-                    std::cout << std::setfill('0') << std::setw(2) << ipc << ":"
-                              << std::setfill(' ') << std::setw(maxNameLength)
-                              << label << spacer << std::setprecision(2)
-                              << std::scientific << std::setw(9) << L2 << spacer
-                              << L1 << spacer << std::setprecision(6)
-                              << std::fixed << time_of_max << std::endl;
+                    ss << std::setfill('0') << std::setw(2) << ipc << ":"
+                           << std::setfill(' ') << std::setw(maxNameLength)
+                           << label << spacer << std::setprecision(2)
+                           << std::scientific << std::setw(9) << L2 << spacer
+                           << L1 << spacer << std::setprecision(6) << std::fixed
+                           << time_of_max << std::endl;
                 }
                 ++ipc;
             }
         }
-        stream << "Path constraint values at each mesh point:" << std::endl;
-        stream << "      time  ";
+        ss << "Path constraint values at each mesh point:" << std::endl;
+        ss << "      time  ";
         for (int ipc = 0; ipc < (int)pathconNames.size(); ++ipc) {
-            stream << std::setw(9) << ipc << "  ";
+            ss << std::setw(9) << ipc << "  ";
         }
-        stream << std::endl;
+        ss << std::endl;
         for (int imesh = 0; imesh < m_numMeshPoints; ++imesh) {
-            stream << std::setfill('0') << std::setw(3) << imesh << "  ";
-            stream.fill(' ');
-            stream << std::setw(9) << it.times(imesh).scalar() << "  ";
+            ss << std::setfill('0') << std::setw(3) << imesh << "  ";
+            ss.fill(' ');
+            ss << std::setw(9) << it.times(imesh).scalar() << "  ";
             for (int ipc = 0; ipc < (int)pathconNames.size(); ++ipc) {
                 const auto& value = constraints.path[ipc](imesh).scalar();
-                stream << std::setprecision(2) << std::scientific
+                ss << std::setprecision(2) << std::scientific
                        << std::setw(9) << value << "  ";
             }
-            stream << std::endl;
+            ss << std::endl;
         }
+    }
+    if (stream.rdbuf() == std::cout.rdbuf()) {
+        OpenSim::log_cout(ss.str());
+    } else {
+        stream << ss.str() << std::endl;
     }
 }
 
 void Transcription::printObjectiveBreakdown(const Iterate& it,
         const casadi::DM& objectiveTerms,
         std::ostream& stream) const {
-    stream << "Breakdown of objective (including weights):";
+    std::stringstream ss;
+    ss << "Breakdown of objective (including weights):";
     if (objectiveTerms.numel() == 0) {
-        stream << " no terms\n";
+        ss << " no terms";
     } else {
-        stream << "\n";
         for (int io = 0; io < (int)m_objectiveTermNames.size(); ++io) {
-            stream << "  " << m_objectiveTermNames[io] << ": "
-                   << objectiveTerms(io).scalar() << "\n";
+            ss << "\n  " << m_objectiveTermNames[io] << ": "
+                   << objectiveTerms(io).scalar();
         }
     }
-    stream << std::flush;
+    if (stream.rdbuf() == std::cout.rdbuf()) {
+        OpenSim::log_cout(ss.str());
+    } else {
+        stream << ss.str() << std::endl;
+    }
 }
 
 Iterate Transcription::createInitialGuessFromBounds() const {

--- a/Moco/Moco/MocoCasADiSolver/CasOCTranscription.h
+++ b/Moco/Moco/MocoCasADiSolver/CasOCTranscription.h
@@ -49,10 +49,10 @@ public:
         const auto shape = meshIndices.size();
         OPENSIM_THROW_IF(shape.first != 1 || shape.second != m_numGridPoints,
                 OpenSim::Exception,
-                OpenSim::format(
+                fmt::format(
                         "createMeshIndicesImpl() must return a "
-                        "row vector of shape length [1, %i], but a matrix of "
-                        "shape [%i, %i] was returned.",
+                        "row vector of shape length [1, {}], but a matrix of "
+                        "shape [{}, {}] was returned.",
                         m_numGridPoints, shape.first, shape.second));
         OPENSIM_THROW_IF(!SimTK::isNumericallyEqual(
                                  casadi::DM::sum2(meshIndices).scalar(),

--- a/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -188,10 +188,10 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
         OPENSIM_THROW_IF(get_transcription_scheme() != "hermite-simpson" &&
                                  get_enforce_constraint_derivatives(),
                 Exception,
-                format("If enforcing derivatives of model kinematic "
+                fmt::format("If enforcing derivatives of model kinematic "
                        "constraints, then the property 'transcription_scheme' "
                        "must be set to 'hermite-simpson'. "
-                       "Currently, it is set to '%s'.",
+                       "Currently, it is set to '{}'.",
                         get_transcription_scheme()));
     }
 
@@ -289,9 +289,9 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
     casSolver->setMinimizeImplicitMultibodyAccelerations(
             get_minimize_implicit_multibody_accelerations());
     OPENSIM_THROW_IF(get_implicit_multibody_accelerations_weight() < 0,
-            Exception, format(
+            Exception, fmt::format(
                 "Property implicit_multibody_accelerations_weight must be "
-                "non-negative, but it is set to %f.",
+                "non-negative, but it is set to {}.",
                 get_implicit_multibody_accelerations_weight()));
     casSolver->setImplicitMultibodyAccelerationsWeight(
             get_implicit_multibody_accelerations_weight());
@@ -301,9 +301,9 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
     casSolver->setMinimizeImplicitAuxiliaryDerivatives(
             get_minimize_implicit_auxiliary_derivatives());
     OPENSIM_THROW_IF(get_implicit_auxiliary_derivatives_weight() < 0,
-            Exception, format(
+            Exception, fmt::format(
                     "Property implicit_auxiliary_derivatives_weight must be "
-                    "non-negative, but it is set to %f.",
+                    "non-negative, but it is set to {}.",
                     get_implicit_auxiliary_derivatives_weight()));
     casSolver->setImplicitAuxiliaryDerivativesWeight(
             get_implicit_auxiliary_derivatives_weight());

--- a/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
@@ -115,22 +115,18 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
             // constraint derivatives? For now, disallow enforcing derivatives
             // if non-holonomic or acceleration constraints present.
             OPENSIM_THROW_IF(enforceConstraintDerivs && mv != 0, Exception,
-                    format("Enforcing constraint derivatives is supported only "
-                           "for "
-                           "holonomic (position-level) constraints. "
-                           "There are %i velocity-level "
-                           "scalar constraints associated with the model "
-                           "Constraint "
-                           "at ConstraintIndex %i.",
+                    fmt::format("Enforcing constraint derivatives is supported "
+                                "only for holonomic (position-level) "
+                                "constraints. There are {} velocity-level "
+                                "scalar constraints associated with the model "
+                                "Constraint at ConstraintIndex {}.",
                             mv, cid));
             OPENSIM_THROW_IF(enforceConstraintDerivs && ma != 0, Exception,
-                    format("Enforcing constraint derivatives is supported only "
-                           "for "
-                           "holonomic (position-level) constraints. "
-                           "There are %i acceleration-level "
-                           "scalar constraints associated with the model "
-                           "Constraint "
-                           "at ConstraintIndex %i.",
+                    fmt::format("Enforcing constraint derivatives is supported "
+                                "only for holonomic (position-level) "
+                                "constraints. There are {} acceleration-level "
+                                "scalar constraints associated with the model "
+                                "Constraint at ConstraintIndex {}.",
                             ma, cid));
 
             total_mp += mp;
@@ -182,10 +178,9 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
                         OPENSIM_THROW_IF(
                                 multInfo.getName().substr(0, 6) != "lambda",
                                 Exception,
-                                OpenSim::format(
-                                        "Expected the multiplier name for "
-                                        "this constraint to begin with "
-                                        "'lambda' but it begins with '%s'.",
+                                fmt::format("Expected the multiplier name for "
+                                            "this constraint to begin with "
+                                            "'lambda' but it begins with '{}'.",
                                         multInfo.getName().substr(0, 6)));
                         const auto vcBounds = convertBounds(
                                 mocoCasADiSolver
@@ -245,6 +240,6 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
     }
 
     m_fileDeletionThrower = OpenSim::make_unique<FileDeletionThrower>(
-            format("delete_this_to_stop_optimization_%s_%s.txt",
+            fmt::format("delete_this_to_stop_optimization_{}_{}.txt",
                     problemRep.getName(), m_formattedTimeString));
 }

--- a/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -102,8 +102,8 @@ template <typename VectorType = SimTK::Vector>
 VectorType convertToSimTKVector(const casadi::DM& casVector) {
     OPENSIM_THROW_IF(casVector.columns() != 1 && casVector.rows() != 1,
             Exception,
-            format("casVector should be 1-dimensional, but has size %i x "
-                   "%i.",
+            fmt::format("casVector should be 1-dimensional, but has size {} x "
+                        "{}.",
                     casVector.rows(), casVector.columns()));
     VectorType simtkVector((int)casVector.numel());
     for (int i = 0; i < casVector.numel(); ++i) {
@@ -446,8 +446,9 @@ private:
     }
     void intermediateCallbackWithIterateImpl(
             const CasOC::Iterate& iterate) const override {
-        std::string filename = format("MocoCasADiSolver_%s_trajectory%06i.sto",
-                m_formattedTimeString, iterate.iteration);
+        std::string filename =
+                fmt::format("MocoCasADiSolver_{}_trajectory{:06i}.sto",
+                        m_formattedTimeString, iterate.iteration);
         convertToMocoTrajectory(iterate).write(filename);
     }
 

--- a/Moco/Moco/MocoConstraintInfo.cpp
+++ b/Moco/Moco/MocoConstraintInfo.cpp
@@ -38,18 +38,19 @@ std::vector<std::string> MocoConstraintInfo::getConstraintLabels() const {
     return labels;
 }
 
-void MocoConstraintInfo::printDescription(std::ostream& stream) const {
-    stream << getName() << ". " << getConcreteClassName() <<
-            ". number of scalar equations: " << getNumEquations();
+void MocoConstraintInfo::printDescription() const {
+    std::string str = fmt::format("  {}. {}. number of scalar equations: {}",
+            getName(), getConcreteClassName(), getNumEquations());
 
     const std::vector<MocoBounds> bounds = getBounds();
-    stream << ". bounds: ";
-    for (int i = 0; i < (int)bounds.size(); ++i) {
-        bounds[i].printDescription(stream);
-        if (i < (int)bounds.size() - 1)
-            stream << ", ";
+    std::vector<std::string> boundsStr;
+    for (const auto& bound : bounds) {
+        std::stringstream ss;
+        ss << bound;
+        boundsStr.push_back(ss.str());
     }
-    stream << std::endl;
+    str += fmt::format(". bounds: {}", fmt::join(boundsStr, ", "));
+    log_cout(str);
 }
 
 void MocoConstraintInfo::constructProperties() {

--- a/Moco/Moco/MocoConstraintInfo.h
+++ b/Moco/Moco/MocoConstraintInfo.h
@@ -91,7 +91,7 @@ public:
 
     /// Print the name, type, number of scalar equations, and bounds for this
     /// constraint.
-    void printDescription(std::ostream& stream = std::cout) const;
+    void printDescription() const;
 
 private:
     OpenSim_DECLARE_LIST_PROPERTY(bounds, MocoBounds,

--- a/Moco/Moco/MocoConstraintInfo.h
+++ b/Moco/Moco/MocoConstraintInfo.h
@@ -126,7 +126,7 @@ private:
     void checkPropertySize(const AbstractProperty& prop) {
         if (!prop.empty()) {
             OPENSIM_THROW_IF(m_num_equations != prop.size(), Exception,
-                    format("Size of property %s is not consistent with "
+                    fmt::format("Size of property {} is not consistent with "
                            "current number of constraint equations.",
                             prop.getName()));
         }

--- a/Moco/Moco/MocoControlBoundConstraint.cpp
+++ b/Moco/Moco/MocoControlBoundConstraint.cpp
@@ -47,10 +47,8 @@ void MocoControlBoundConstraint::initializeOnModelImpl(
     m_hasLower = !getProperty_lower_bound().empty();
     m_hasUpper = !getProperty_upper_bound().empty();
     if (getProperty_control_paths().size() && !m_hasLower && !m_hasUpper) {
-        std::cout << "Warning: In MocoControlBoundConstraint '" << getName()
-                  << "', control paths are specified but no bounds "
-                     "are provided."
-                  << std::endl;
+        log_warn("In MocoControlBoundConstraint '{}', control paths are "
+                 "specified but no bounds are provided.", getName());
     }
     // Make sure there are no nonexistent controls.
     if (m_hasLower || m_hasUpper) {
@@ -59,8 +57,8 @@ void MocoControlBoundConstraint::initializeOnModelImpl(
             const auto& thisName = get_control_paths(i);
             OPENSIM_THROW_IF_FRMOBJ(systemControlIndexMap.count(thisName) == 0,
                     Exception,
-                    format("Control path '%s' was provided but no such control "
-                           "exists in the model.", thisName));
+                    fmt::format("Control path '{}' was provided but no such "
+                                "control exists in the model.", thisName));
             m_controlIndices.push_back(systemControlIndexMap[thisName]);
         }
     }
@@ -75,15 +73,15 @@ void MocoControlBoundConstraint::initializeOnModelImpl(
         if (auto* spline = dynamic_cast<const GCVSpline*>(&f)) {
             OPENSIM_THROW_IF_FRMOBJ(
                     spline->getMinX() > problemInfo.minInitialTime, Exception,
-                    format("The function's minimum domain value (%f) must "
+                    fmt::format("The function's minimum domain value ({}) must "
                            "be less than or equal to the minimum possible "
-                           "initial time (%f).",
+                           "initial time ({}).",
                             spline->getMinX(), problemInfo.minInitialTime));
             OPENSIM_THROW_IF_FRMOBJ(
                     spline->getMaxX() < problemInfo.maxFinalTime, Exception,
-                    format("The function's maximum domain value (%f) must "
+                    fmt::format("The function's maximum domain value ({}) must "
                            "be greater than or equal to the maximum possible "
-                           "final time (%f).",
+                           "final time ({}).",
                             spline->getMaxX(), problemInfo.maxFinalTime));
         }
     };

--- a/Moco/Moco/MocoFrameDistanceConstraint.cpp
+++ b/Moco/Moco/MocoFrameDistanceConstraint.cpp
@@ -63,26 +63,28 @@ void MocoFrameDistanceConstraint::initializeOnModelImpl(
     for (int i = 0; i < nFramePairs; ++i) {
         const auto frame1_path = get_frame_pairs(i).get_frame1_path();
         OPENSIM_THROW_IF(!model.hasComponent<Frame>(frame1_path), Exception,
-                format("Could not find frame '%s'.", frame1_path));
+                fmt::format("Could not find frame '{}'.", frame1_path));
         auto& frame1 = model.getComponent<Frame>(frame1_path);
         const auto frame2_path = get_frame_pairs(i).get_frame2_path();
         OPENSIM_THROW_IF(!model.hasComponent<Frame>(frame2_path), Exception,
-                format("Could not find frame '%s'.", frame2_path));
+                fmt::format("Could not find frame '{}'.", frame2_path));
         auto& frame2 = model.getComponent<Frame>(frame2_path);
         m_frame_pairs.emplace_back(&frame1, &frame2);
 
         const double& minimum = get_frame_pairs(i).get_minimum_distance();
         const double& maximum = get_frame_pairs(i).get_maximum_distance();
-        OPENSIM_THROW_IF(minimum < 0, Exception, 
-                format("Expected the minimum distance for this frame pair to " 
-                    "non-negative, but it is %d.", minimum));
+        OPENSIM_THROW_IF(minimum < 0, Exception,
+                fmt::format("Expected the minimum distance for this frame pair "
+                            "to non-negative, but it is {}.",
+                        minimum));
         OPENSIM_THROW_IF(maximum < 0, Exception,
-                format("Expected the maximum distance for this frame pair to "
-                       "non-negative, but it is %d.", maximum));
+                fmt::format("Expected the maximum distance for this frame pair "
+                            "to non-negative, but it is {}.", maximum));
         OPENSIM_THROW_IF(minimum > maximum, Exception,
-                format("Expected the minimum distance for this frame pair to "
-                       "be less than or equal to the maximum distance, but "
-                       "they are %d and %d, respectively.", minimum, maximum));
+                fmt::format("Expected the minimum distance for this frame pair "
+                            "to be less than or equal to the maximum distance, "
+                            "but they are {} and {}, respectively.",
+                        minimum, maximum));
         bounds.emplace_back(SimTK::square(minimum), SimTK::square(maximum));
     }
 
@@ -93,9 +95,9 @@ void MocoFrameDistanceConstraint::initializeOnModelImpl(
         m_projectionType = ProjectionType::Plane;
     } else if (get_projection() != "none") {
         OPENSIM_THROW_FRMOBJ(
-                Exception, format("Expected 'projection' to be 'none', "
-                                  "'vector', or 'plane', but got '%s'.",
-                get_projection()));
+                Exception, fmt::format("Expected 'projection' to be 'none', "
+                                       "'vector', or 'plane', but got '{}'.",
+                                   get_projection()));
     }
     if (m_projectionType != ProjectionType::None) {
         OPENSIM_THROW_IF_FRMOBJ(getProperty_projection_vector().empty(),

--- a/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.cpp
@@ -119,15 +119,11 @@ void MocoAccelerationTrackingGoal::calcIntegrandImpl(const SimTK::State& state,
     }
 }
 
-void MocoAccelerationTrackingGoal::printDescriptionImpl(
-        std::ostream& stream) const {
-    stream << "        ";
-    stream << "acceleration reference file: " 
-           << get_acceleration_reference_file()
-           << std::endl;
+void MocoAccelerationTrackingGoal::printDescriptionImpl() const {
+    log_cout("        acceleration reference file: {}",
+            get_acceleration_reference_file());
     for (int i = 0; i < (int)m_frame_paths.size(); i++) {
-        stream << "        ";
-        stream << "frame " << i << ": " << m_frame_paths[i] << ", ";
-        stream << "weight: " << m_acceleration_weights[i] << std::endl;
+        log_cout("        frame {}: {}, weight: {}", i, m_frame_paths[i],
+                m_acceleration_weights[i]);
     }
 }

--- a/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.cpp
@@ -56,19 +56,19 @@ void MocoAccelerationTrackingGoal::initializeOnModelImpl(
             const auto& labels = accelerationTableToUse.getColumnLabels();
             for (int i = 0; i < getProperty_frame_paths().size(); ++i) {
                 const auto& path = get_frame_paths(i);
-                OPENSIM_THROW_IF_FRMOBJ(
-                    std::find(labels.begin(), labels.end(), path) == 
-                        labels.end(),
-                    Exception,
-                    format("Expected frame_paths to match one of the "
-                       "column labels in the acceleration reference, but frame "
-                       "path '%s' not found in the reference labels.", path));
+                OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
+                                                path) == labels.end(),
+                        Exception,
+                        fmt::format("Expected frame_paths to match one of the "
+                                    "column labels in the acceleration "
+                                    "reference, but frame path '{}' not found "
+                                    "in the reference labels.",
+                                path));
                 m_frame_paths.push_back(path);
                 accelerationTable.appendColumn(path, 
                     accelerationTableToUse.getDependentColumn(path));
             }
         }
-
     }
 
     // Check that there are no redundant columns in the reference data.

--- a/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.h
@@ -114,7 +114,7 @@ protected:
             const GoalInput& input, SimTK::Vector& goal) const override {
             goal[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(acceleration_reference_file, std::string,

--- a/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.cpp
@@ -61,11 +61,12 @@ void MocoAngularVelocityTrackingGoal::initializeOnModelImpl(
                 OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
                                                 path) == labels.end(),
                         Exception,
-                        format("Expected frame_paths to match one of the "
-                               "column labels in the angular velocity "
-                               "reference, but "
-                               "frame path '%s' not found in the reference "
-                               "labels.",
+                        fmt::format(
+                                "Expected frame_paths to match one of the "
+                                "column labels in the angular velocity "
+                                "reference, but "
+                                "frame path '{}' not found in the reference "
+                                "labels.",
                                 path));
                 m_frame_paths.push_back(path);
                 angularVelocityTable.appendColumn(path,

--- a/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.cpp
@@ -162,14 +162,11 @@ void MocoAngularVelocityTrackingGoal::calcIntegrandImpl(
     }
 }
 
-void MocoAngularVelocityTrackingGoal::printDescriptionImpl(
-        std::ostream& stream) const {
-    stream << "        ";
-    stream << "angular velocity reference file: "
-           << get_angular_velocity_reference_file() << std::endl;
+void MocoAngularVelocityTrackingGoal::printDescriptionImpl() const {
+    log_cout("        angular velocity reference file: {}",
+            get_angular_velocity_reference_file());
     for (int i = 0; i < (int)m_frame_paths.size(); i++) {
-        stream << "        ";
-        stream << "frame " << i << ": " << m_frame_paths[i] << ", ";
-        stream << "weight: " << m_angular_velocity_weights[i] << std::endl;
+        log_cout("        frame {}: {}, weight: {}", i, m_frame_paths[i],
+                m_angular_velocity_weights[i]);
     }
 }

--- a/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.h
@@ -142,7 +142,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(states_reference, TableProcessor,

--- a/Moco/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -112,9 +112,8 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& group = get_contact_groups(ig);
 
         OPENSIM_THROW_IF_FRMOBJ(
-                !extLoads->contains(group.get_external_force_name()),
-                Exception,
-                format("External force '%s' not found.",
+                !extLoads->contains(group.get_external_force_name()), Exception,
+                fmt::format("External force '{}' not found.",
                         group.get_external_force_name()));
         const auto& extForce =
                 extLoads->get(group.get_external_force_name());
@@ -156,10 +155,10 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
                         &model.getComponent<PhysicalFrame>(
                                 "./bodyset/" + forceExpressedInBody);
             } else {
-                OPENSIM_THROW_FRMOBJ(
-                        Exception, format("Could not find '%s' in the model or "
-                                          "the BodySet.",
-                                           forceExpressedInBody));
+                OPENSIM_THROW_FRMOBJ(Exception,
+                        fmt::format("Could not find '{}' in the model or "
+                                    "the BodySet.",
+                                forceExpressedInBody));
             }
         }
 
@@ -173,8 +172,8 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
         m_projectionType = ProjectionType::Plane;
     } else if (get_projection() != "none") {
         OPENSIM_THROW_FRMOBJ(
-                Exception, format("Expected 'projection' to be 'none', "
-                                  "'vector', or 'plane', but got '%s'.",
+                Exception, fmt::format("Expected 'projection' to be 'none', "
+                                       "'vector', or 'plane', but got '{}'.",
                                    get_projection()));
     }
     if (m_projectionType != ProjectionType::None) {
@@ -231,10 +230,10 @@ int MocoContactTrackingGoal::findRecordOffset(
     }
 
     OPENSIM_THROW_FRMOBJ(Exception,
-            format("Contact force '%s' has sphere base frame '%s' "
-                  "and half space base frame '%s'. One of these "
+            fmt::format("Contact force '{}' has sphere base frame '{}' "
+                  "and half space base frame '{}'. One of these "
                    "frames should match the applied_to_body "
-                   "setting ('%s') of ExternalForce '%s', or match one of "
+                   "setting ('{}') of ExternalForce '{}', or match one of "
                    "the alternative_frame_paths, but no match found.",
                     contactForce.getAbsolutePathString(),
                     sphereBaseName, halfSpaceBaseName, appliedToBody,

--- a/Moco/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -288,25 +288,19 @@ void MocoContactTrackingGoal::calcIntegrandImpl(
     }
 }
 
-void MocoContactTrackingGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "projection type: " << get_projection() << std::endl;
+void MocoContactTrackingGoal::printDescriptionImpl() const {
+    log_cout("        projection type: {}", get_projection());
     if (m_projectionType != ProjectionType::None) {
-        stream << "        ";
-        stream << "projection vector: " << get_projection_vector() << std::endl;
+        log_cout("        projection vector: {}", get_projection_vector());
     }
     for (int ig = 0; ig < getProperty_contact_groups().size(); ++ig) {
         const auto& group = get_contact_groups(ig);
-        stream << "        ";
-        stream << "group " << ig
-               << ": ExternalForce: " << group.get_external_force_name()
-               << std::endl;
-        stream << "            ";
-        stream << "forces: " << std::endl;
+        log_cout("        group {}: ExternalForce: {}",
+                ig, group.get_external_force_name());
+        log_cout("            forces:");
         for (int ic = 0; ic < group.getProperty_contact_force_paths().size();
                 ++ic) {
-            stream << "                ";
-            stream << group.get_contact_force_paths(ic) << std::endl;
+            log_cout("                {}", group.get_contact_force_paths(ic));
         }
     }
 }

--- a/Moco/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -221,7 +221,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral / m_denominator;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_LIST_PROPERTY(contact_groups, MocoContactTrackingGoalGroup,

--- a/Moco/Moco/MocoGoal/MocoControlGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoControlGoal.cpp
@@ -138,10 +138,9 @@ void MocoControlGoal::calcGoalImpl(
     }
 }
 
-void MocoControlGoal::printDescriptionImpl(std::ostream& stream) const {
+void MocoControlGoal::printDescriptionImpl() const {
     for (int i = 0; i < (int) m_controlNames.size(); i++) {
-        stream << "        ";
-        stream << "control: " << m_controlNames[i]
-               << ", weight: " << m_weights[i] << std::endl;
+        log_cout("        control: {}, weight: {}", m_controlNames[i],
+                m_weights[i]);
     }
 }

--- a/Moco/Moco/MocoGoal/MocoControlGoal.h
+++ b/Moco/Moco/MocoGoal/MocoControlGoal.h
@@ -99,7 +99,7 @@ protected:
             const SimTK::State& state, double& integrand) const override;
     void calcGoalImpl(
             const GoalInput& input, SimTK::Vector& cost) const override;
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     void constructProperties();

--- a/Moco/Moco/MocoGoal/MocoControlTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoControlTrackingGoal.cpp
@@ -47,7 +47,7 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& weightName = get_control_weights().get(i).getName();
         if (allControlIndices.count(weightName) == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    format("Weight provided with name '%s' but this is "
+                    fmt::format("Weight provided with name '{}' but this is "
                            "not a recognized control.", weightName));
         }
     }
@@ -64,12 +64,12 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& controlName = get_reference_labels(i).getName();
         if (allControlIndices.count(controlName) == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                format("Control '%s' does not exist in the model.",
+                fmt::format("Control '{}' does not exist in the model.",
                         controlName));
         }
         OPENSIM_THROW_IF_FRMOBJ(controlsToTrack.count(controlName), Exception,
-                format("Expected control '%s' to be provided no more than once,"
-                       "but it is provided more than once.",
+                fmt::format("Expected control '{}' to be provided no more "
+                            "than once, but it is provided more than once.",
                         controlName));
         controlsToTrack.insert(controlName);
         refLabels[controlName] = get_reference_labels(i).get_reference();
@@ -89,9 +89,10 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
         for (const auto& control : controlsToTrack) {
             OPENSIM_THROW_IF_FRMOBJ(!allSplines.contains(refLabels[control]),
                     Exception,
-                    format("Expected reference to contain label '%s', which "
-                           "was associated with control '%s', but no such "
-                           "label exists.", refLabels[control], control));
+                    fmt::format("Expected reference to contain label '{}', "
+                                "which was associated with control '{}', but "
+                                "no such label exists.",
+                            refLabels[control], control));
         }
     } else {
         // The goal is in 'auto' labeling mode;
@@ -101,8 +102,9 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
             if (allControlIndices.count(refLabel) == 0) {
                 if (get_allow_unused_references()) { continue; }
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        format("Reference contains column '%s' which does not "
-                               "match the name of any control variables.",
+                        fmt::format("Reference contains column '{}' which does "
+                                    "not match the name of any control "
+                                    "variables.",
                                 refLabel));
             }
             // In this labeling mode, the refLabel is the control name.

--- a/Moco/Moco/MocoGoal/MocoControlTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoControlTrackingGoal.cpp
@@ -160,12 +160,10 @@ void MocoControlTrackingGoal::calcIntegrandImpl(const SimTK::State& state,
     }
 }
 
-void MocoControlTrackingGoal::printDescriptionImpl(std::ostream& stream) const {
+void MocoControlTrackingGoal::printDescriptionImpl() const {
     for (int i = 0; i < (int)m_control_names.size(); i++) {
-        stream << "        ";
-        stream << "control: " << m_control_names[i]
-                << ", reference label: " << m_ref_labels[i]
-                << ", weight: " << m_control_weights[i] << std::endl;
+        log_cout("        control: {}, reference label: {}, weight: {}",
+                m_control_names[i], m_ref_labels[i], m_control_weights[i]);
     }
 }
 

--- a/Moco/Moco/MocoGoal/MocoControlTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoControlTrackingGoal.h
@@ -213,7 +213,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(reference, TableProcessor,

--- a/Moco/Moco/MocoGoal/MocoControlTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoControlTrackingGoal.h
@@ -196,7 +196,7 @@ public:
             }
         }
         OPENSIM_THROW_FRMOBJ(Exception,
-                format("No reference label provided for control '%s'.",
+                fmt::format("No reference label provided for control '{}'.",
                         control));
     }
 

--- a/Moco/Moco/MocoGoal/MocoGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoGoal.cpp
@@ -35,15 +35,15 @@ MocoGoal::MocoGoal(std::string name, double weight)
 }
 
 
-void MocoGoal::printDescription(std::ostream& stream) const {
+void MocoGoal::printDescription() const {
     const auto mode = getModeAsString();
-    stream << getName() << ". " << getConcreteClassName() <<
-            ", enabled: " << get_enabled() << ", mode: " << mode;
+    std::string str = fmt::format("  {}. {}, enabled: {}, mode: {}",
+            getName(), getConcreteClassName(), get_enabled(), mode);
     if (mode == "cost") {
-        stream << ", weight: " << get_weight();
+        str += fmt::format(", weight: {}", get_weight());
     }
-    stream << std::endl;
-    printDescriptionImpl(stream);
+    log_cout(str);
+    printDescriptionImpl();
 }
 
 double MocoGoal::calcSystemDisplacement(const SimTK::State& initialState,

--- a/Moco/Moco/MocoGoal/MocoGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoGoal.cpp
@@ -48,7 +48,6 @@ void MocoGoal::printDescription() const {
 
 double MocoGoal::calcSystemDisplacement(const SimTK::State& initialState,
         const SimTK::State& finalState) const {
-    log_info("hi");
     const SimTK::Vec3 comInitial =
             getModel().calcMassCenterPosition(initialState);
     const SimTK::Vec3 comFinal =

--- a/Moco/Moco/MocoGoal/MocoGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoGoal.cpp
@@ -48,6 +48,7 @@ void MocoGoal::printDescription(std::ostream& stream) const {
 
 double MocoGoal::calcSystemDisplacement(const SimTK::State& initialState,
         const SimTK::State& finalState) const {
+    log_info("hi");
     const SimTK::Vec3 comInitial =
             getModel().calcMassCenterPosition(initialState);
     const SimTK::Vec3 comFinal =

--- a/Moco/Moco/MocoGoal/MocoGoal.h
+++ b/Moco/Moco/MocoGoal/MocoGoal.h
@@ -253,8 +253,9 @@ private:
     void checkMode(const std::string& mode) const {
         OPENSIM_THROW_IF_FRMOBJ(mode != "cost" && mode != "endpoint_constraint",
                 Exception,
-                format("Expected mode to be 'cost' or 'endpoint_constraint' "
-                       "but got %s.",
+                fmt::format(
+                        "Expected mode to be 'cost' or 'endpoint_constraint' "
+                        "but got {}.",
                         mode));
     }
 

--- a/Moco/Moco/MocoGoal/MocoGoal.h
+++ b/Moco/Moco/MocoGoal/MocoGoal.h
@@ -183,7 +183,7 @@ public:
 
     /// Print the name type and mode of this goal. In cost mode, this prints the
     /// weight.
-    void printDescription(std::ostream& stream = std::cout) const;
+    void printDescription() const;
 
 protected:
     /// Perform any caching before the problem is solved.
@@ -223,8 +223,7 @@ protected:
     virtual void calcGoalImpl(
             const GoalInput& input, SimTK::Vector& goal) const = 0;
     /// Print a more detailed description unique to each goal.
-    virtual void printDescriptionImpl(
-            std::ostream& stream = std::cout) const {};
+    virtual void printDescriptionImpl() const {};
     /// For use within virtual function implementations.
     const Model& getModel() const {
         OPENSIM_THROW_IF_FRMOBJ(!m_model, Exception,

--- a/Moco/Moco/MocoGoal/MocoJointReactionGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoJointReactionGoal.cpp
@@ -153,25 +153,16 @@ void MocoJointReactionGoal::calcIntegrandImpl(
     }
 }
 
-void MocoJointReactionGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "joint path: " << get_joint_path() << std::endl;
-    stream << "        ";
-    stream << "loads frame: " << get_loads_frame() << std::endl;
-    stream << "        ";
-    stream << "expressed: " << get_expressed_in_frame_path() << std::endl;
-    stream << "        ";
-    stream << "reaction measures: ";
-    for (int i = 0; i < getProperty_reaction_measures().size(); i++) {
-        stream << get_reaction_measures(i);
-        if (i < getProperty_reaction_measures().size() - 1) { stream << ", "; }
+void MocoJointReactionGoal::printDescriptionImpl() const {
+    log_cout("        joint path: ", get_joint_path());
+    log_cout("        loads frame: ", get_loads_frame());
+    log_cout("        expressed: ", get_expressed_in_frame_path());
+
+    std::vector<std::string> measures(getProperty_reaction_measures().size());
+    for (int i = 0; i < (int)measures.size(); i++) {
+        measures[i] = get_reaction_measures(i);
     }
-    stream << std::endl;
-    stream << "        ";
-    stream << "reaction weights: ";
-    for (int i = 0; i < (int)m_measureWeights.size(); ++i) {
-        stream << m_measureWeights[i];
-        if (i < (int)m_measureWeights.size() - 1) { stream << ", "; }
-    }
-    stream << std::endl;
+    log_cout("        reaction measures: {}", fmt::join(measures, ", "));
+
+    log_cout("        reaction weights: {}", fmt::join(m_measureWeights, ", "));
 }

--- a/Moco/Moco/MocoGoal/MocoJointReactionGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoJointReactionGoal.cpp
@@ -80,7 +80,7 @@ void MocoJointReactionGoal::initializeOnModelImpl(const Model& model) const {
                         get_reaction_measures(i)) == allowedMeasures.end()) {
 
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        format("Reaction measure '%s' not recognized.",
+                        fmt::format("Reaction measure '{}' not recognized.",
                                 get_reaction_measures(i)));
             }
             reactionMeasures.push_back(get_reaction_measures(i));

--- a/Moco/Moco/MocoGoal/MocoJointReactionGoal.h
+++ b/Moco/Moco/MocoGoal/MocoJointReactionGoal.h
@@ -109,7 +109,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral / m_denominator;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(joint_path, std::string, 

--- a/Moco/Moco/MocoGoal/MocoMarkerFinalGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoMarkerFinalGoal.cpp
@@ -39,10 +39,7 @@ void MocoMarkerFinalGoal::constructProperties() {
     constructProperty_reference_location(SimTK::Vec3(0));
 }
 
-void MocoMarkerFinalGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "point name: " << get_point_name() << std::endl;
-    stream << "        ";
-    stream << "reference location: "
-           << get_reference_location() << std::endl;
+void MocoMarkerFinalGoal::printDescriptionImpl() const {
+    log_cout("        point name: {}", get_point_name());
+    log_cout("        reference location: {}", get_reference_location());
 }

--- a/Moco/Moco/MocoGoal/MocoMarkerFinalGoal.h
+++ b/Moco/Moco/MocoGoal/MocoMarkerFinalGoal.h
@@ -54,7 +54,7 @@ protected:
     void initializeOnModelImpl(const Model&) const override;
     void calcGoalImpl(
             const GoalInput& input, SimTK::Vector& cost) const override;
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 private:
 
     OpenSim_DECLARE_PROPERTY(point_name, std::string,

--- a/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.cpp
@@ -107,17 +107,15 @@ void MocoMarkerTrackingGoal::initializeOnModelImpl(const Model& model) const {
     }
 }
 
-void MocoMarkerTrackingGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "allow unused references: "
-           << get_allow_unused_references() << std::endl;
-    stream << "        ";
-    stream << "tracked marker(s): " << std::endl;
+void MocoMarkerTrackingGoal::printDescriptionImpl() const {
+    log_cout(
+            "        allow unused references: ", get_allow_unused_references());
+    log_cout("        tracked marker(s):");
     int weightIndex = 0;
-    for (auto name : m_marker_names) {
-       stream << "            ";
-       stream << name << ", weight: " << m_marker_weights[weightIndex] << std::endl;
-       weightIndex++;
+    for (const auto& name : m_marker_names) {
+        log_cout("            {}, weight: {}", name,
+                m_marker_weights[weightIndex]);
+        weightIndex++;
     }
 
 }

--- a/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.cpp
@@ -60,9 +60,10 @@ void MocoMarkerTrackingGoal::initializeOnModelImpl(const Model& model) const {
         } else {
             if (!get_allow_unused_references()) {
                 OPENSIM_THROW_FRMOBJ(
-                        Exception, format("Marker '%s' unrecognized by the "
-                                          "specified model.",
-                                           markRefNames[i]));
+                        Exception,
+                        fmt::format("Marker '{}' unrecognized by "
+                                    "the specified model.",
+                                markRefNames[i]));
             }
         }
     }

--- a/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.h
@@ -78,7 +78,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
     OpenSim_DECLARE_PROPERTY(markers_reference, MarkersReference,
             "MarkersReference object containing the marker trajectories to be "

--- a/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -153,7 +153,7 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
                 mat.updElt(irow, icol++) = e[ie];
                 if (!irow) {
                     colLabels.push_back(
-                            fmt::format("%s/quaternion_e{}", label, ie));
+                            fmt::format("{}/quaternion_e{}", label, ie));
                 }
             }
         }

--- a/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -62,9 +62,9 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
                     std::find(labels.begin(), labels.end(), path) ==
                         labels.end(),
                     Exception,
-                    format("Expected frame_paths to match one of the "
+                    fmt::format("Expected frame_paths to match one of the "
                         "column labels in the rotation reference, but frame "
-                        "path '%s' not found in the reference labels.", path));
+                        "path '{}' not found in the reference labels.", path));
                 m_frame_paths.push_back(path);
                 rotationTable.appendColumn(path,
                     rotationTableToUse.getDependentColumn(path));
@@ -152,7 +152,8 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
             for (int ie = 0; ie < e.size(); ++ie) {
                 mat.updElt(irow, icol++) = e[ie];
                 if (!irow) {
-                    colLabels.push_back(format("%s/quaternion_e%i", label, ie));
+                    colLabels.push_back(
+                            fmt::format("%s/quaternion_e{}", label, ie));
                 }
             }
         }

--- a/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -205,15 +205,12 @@ void MocoOrientationTrackingGoal::calcIntegrandImpl(const SimTK::State& state,
     }
 }
 
-void MocoOrientationTrackingGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "rotation reference file: "
-           << get_rotation_reference_file()
-           << std::endl;
+void MocoOrientationTrackingGoal::printDescriptionImpl() const {
+    log_cout("        rotation reference file: {}",
+            get_rotation_reference_file());
     for (int i = 0; i < (int)m_frame_paths.size(); i++) {
-        stream << "        ";
-        stream << "frame " << i << ": " << m_frame_paths[i] << ", ";
-        stream << "weight: " << m_rotation_weights[i] << std::endl;
+        log_cout("        frame {}: {}, weight: {}",
+                i, m_frame_paths[i], m_rotation_weights[i]);
     }
 }
 

--- a/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.h
@@ -143,7 +143,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(states_reference, TableProcessor,

--- a/Moco/Moco/MocoGoal/MocoPeriodicityGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoPeriodicityGoal.cpp
@@ -65,10 +65,10 @@ void MocoPeriodicityGoal::initializeOnModelImpl(const Model& model) const {
     for (int i = 0; i < nStatePairs; ++i) {
         const auto path1 = get_state_pairs(i).get_initial_variable();
         OPENSIM_THROW_IF(allSysYIndices.count(path1) == 0, Exception,
-                format("Could not find state '%s'.", path1));
+                fmt::format("Could not find state '{}'.", path1));
         const auto path2 = get_state_pairs(i).get_final_variable();
         OPENSIM_THROW_IF(allSysYIndices.count(path2) == 0, Exception,
-                format("Could not find state '%s'.", path2));
+                fmt::format("Could not find state '{}'.", path2));
         int stateIndex1 = allSysYIndices[path1];
         int stateIndex2 = allSysYIndices[path2];
         m_state_names.emplace_back(path1, path2);
@@ -82,10 +82,10 @@ void MocoPeriodicityGoal::initializeOnModelImpl(const Model& model) const {
     for (int i = 0; i < nControlPairs; ++i) {
         const auto path1 = get_control_pairs(i).get_initial_variable();
         OPENSIM_THROW_IF(systemControlIndexMap.count(path1) == 0, Exception,
-                format("Could not find control '%s'.", path1));
+                fmt::format("Could not find control '{}'.", path1));
         const auto path2 = get_control_pairs(i).get_final_variable();
         OPENSIM_THROW_IF(systemControlIndexMap.count(path2) == 0, Exception,
-                format("Could not find control '%s'.", path2));
+                fmt::format("Could not find control '{}'.", path2));
         int controlIndex1 = systemControlIndexMap[path1];
         int controlIndex2 = systemControlIndexMap[path2];
         m_control_names.emplace_back(path1, path2);

--- a/Moco/Moco/MocoGoal/MocoPeriodicityGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoPeriodicityGoal.cpp
@@ -123,19 +123,15 @@ void MocoPeriodicityGoal::calcGoalImpl(
     }
 }
 
-void MocoPeriodicityGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "state periodicity pairs: " << std::endl;
+void MocoPeriodicityGoal::printDescriptionImpl() const {
+    log_cout("        state periodicity pairs:");
     for (const auto& pair : m_state_names) {
-        stream << "                ";
-        stream << "initial: " << pair.first
-               << ", final: " << pair.second << std::endl;
+        log_cout("                initial: {}, final: {}", pair.first,
+                pair.second);
     }
-    stream << "        ";
-    stream << "control periodicity pairs: " << std::endl;
+    log_cout("        control periodicity pairs:");
     for (const auto& pair : m_control_names) {
-        stream << "                ";
-        stream << "initial: " << pair.first
-               << ", final: " << pair.second << std::endl;
+        log_cout("                initial: {}, final: {}", pair.first,
+                pair.second);
     }
 }

--- a/Moco/Moco/MocoGoal/MocoPeriodicityGoal.h
+++ b/Moco/Moco/MocoGoal/MocoPeriodicityGoal.h
@@ -128,7 +128,7 @@ protected:
     void initializeOnModelImpl(const Model& model) const override;
     void calcGoalImpl(
             const GoalInput& input, SimTK::Vector& goal) const override;
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_LIST_PROPERTY(state_pairs, MocoPeriodicityGoalPair,

--- a/Moco/Moco/MocoGoal/MocoStateTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoStateTrackingGoal.cpp
@@ -117,11 +117,10 @@ void MocoStateTrackingGoal::calcIntegrandImpl(/*int meshIndex,*/
     }
 }
 
-void MocoStateTrackingGoal::printDescriptionImpl(std::ostream& stream) const {
+void MocoStateTrackingGoal::printDescriptionImpl() const {
     for (int i = 0; i < (int) m_state_names.size(); i++) {
-        stream << "        ";
-        stream << "state: " << m_state_names[i] << ", "
-               << "weight: " << m_state_weights[i] << std::endl;
+        log_cout("        state: {}, weight: {}", m_state_names[i],
+                m_state_weights[i]);
     }
 }
 

--- a/Moco/Moco/MocoGoal/MocoStateTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoStateTrackingGoal.cpp
@@ -46,14 +46,14 @@ void MocoStateTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& weightName = get_state_weights().get(i).getName();
         if (allSysYIndices.count(weightName) == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                "Weight provided with name '" + weightName + "' but this is "
-                "not a recognized state.");
+                fmt::format("Weight provided with name '{}' but this is "
+                    "not a recognized state.", weightName));
         }
         if (getProperty_pattern().size() &&
                 !std::regex_match(weightName, regex)) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    format("Weight provided with name '%s' but this name does "
-                           "not match the pattern '%s'.",
+                    fmt::format("Weight provided with name '{}' but this name "
+                                "does not match the pattern '{}'.",
                             weightName, get_pattern()));
         }
     }
@@ -68,7 +68,7 @@ void MocoStateTrackingGoal::initializeOnModelImpl(const Model& model) const {
                 continue;
             }
             OPENSIM_THROW_FRMOBJ(Exception,
-                 "State reference '" + refName + "' unrecognized.");
+                 fmt::format("State reference '{}' unrecognized.", refName));
         }
         if (getProperty_pattern().size() &&
                 !std::regex_match(refName, regex)) {
@@ -76,9 +76,10 @@ void MocoStateTrackingGoal::initializeOnModelImpl(const Model& model) const {
                 continue;
             }
             OPENSIM_THROW_FRMOBJ(
-                    Exception, format("State reference '%s' does not match the "
-                                      "pattern '%s'.",
-                                       refName, get_pattern()));
+                    Exception,
+                    fmt::format("State reference '{}' does not match the "
+                                "pattern '{}'.",
+                            refName, get_pattern()));
         }
 
         m_sysYIndices.push_back(allSysYIndices[refName]);

--- a/Moco/Moco/MocoGoal/MocoStateTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoStateTrackingGoal.h
@@ -122,7 +122,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(reference, TableProcessor,

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
@@ -100,11 +100,10 @@ void MocoSumSquaredStateGoal::calcIntegrandImpl(
     }
 }
 
-void MocoSumSquaredStateGoal::printDescriptionImpl(std::ostream& stream) const {
+void MocoSumSquaredStateGoal::printDescriptionImpl() const {
     for (int i = 0; i < (int)m_state_names.size(); i++) {
-        stream << "        ";
-        stream << "state: " << m_state_names[i] << ", "
-               << "weight: " << m_state_weights[i] << std::endl;
+        log_cout("        state: {}, weight: {}", m_state_names[i],
+                m_state_weights[i]);
     }
 }
 

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
@@ -39,15 +39,16 @@ void MocoSumSquaredStateGoal::initializeOnModelImpl(const Model& model) const {
             const auto& weightName = get_state_weights().get(i).getName();
             if (allSysYIndices.count(weightName) == 0) {
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        "Weight provided with name '" + weightName +
-                        "' but this is not a recognized state.");
+                        fmt::format("Weight provided with name '{}' "
+                        "but this is not a recognized state.", weightName));
             }
 
             if (getProperty_pattern().size()) {
                 if (!std::regex_match(weightName, regex)) {
                     OPENSIM_THROW_FRMOBJ(Exception,
-                            format("Weight provided with name '%s' but this "
-                                   "name does not match the pattern '%s'.",
+                            fmt::format("Weight provided with name '{}' but "
+                                        "this name does not match the "
+                                        "pattern '{}'.",
                                     weightName, get_pattern()));
                 }
             }
@@ -70,7 +71,7 @@ void MocoSumSquaredStateGoal::initializeOnModelImpl(const Model& model) const {
         // Pattern must match at least one state.
         if (m_sysYIndices.size() == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    format("Pattern '%s' given but no state variables "
+                    fmt::format("Pattern '{}' given but no state variables "
                            "matched the pattern.", get_pattern()));
         }
     }

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.h
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.h
@@ -92,7 +92,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(state_weights, MocoWeightSet,

--- a/Moco/Moco/MocoGoal/MocoTranslationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoTranslationTrackingGoal.cpp
@@ -57,13 +57,15 @@ void MocoTranslationTrackingGoal::initializeOnModelImpl(const Model& model)
             const auto& labels = translationTableToUse.getColumnLabels();
             for (int i = 0; i < getProperty_frame_paths().size(); ++i) {
                 const auto& path = get_frame_paths(i);
-                OPENSIM_THROW_IF_FRMOBJ(
-                    std::find(labels.begin(), labels.end(), path) ==
-                        labels.end(),
-                    Exception,
-                    format("Expected frame_paths to match one of the "
-                        "column labels in the translation reference, but frame "
-                        "path '%s' not found in the reference labels.", path));
+                OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
+                                                path) == labels.end(),
+                        Exception,
+                        fmt::format(
+                                "Expected frame_paths to match one of the "
+                                "column labels in the translation reference, "
+                                "but frame path '{}' not found in the "
+                                "reference labels.",
+                                path));
                 m_frame_paths.push_back(path);
                 translationTable.appendColumn(path,
                     translationTableToUse.getDependentColumn(path));

--- a/Moco/Moco/MocoGoal/MocoTranslationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoTranslationTrackingGoal.cpp
@@ -160,13 +160,11 @@ void MocoTranslationTrackingGoal::calcIntegrandImpl(const SimTK::State& state,
     }
 }
 
-void MocoTranslationTrackingGoal::printDescriptionImpl(std::ostream& stream) const {
-    stream << "        ";
-    stream << "translation reference file: "
-           << get_translation_reference_file() << std::endl;
+void MocoTranslationTrackingGoal::printDescriptionImpl() const {
+    log_cout("        translation reference file: {}",
+             get_translation_reference_file());
     for (int i = 0; i < (int)m_frame_paths.size(); i++) {
-        stream << "        ";
-        stream << "frame " << i << ": " << m_frame_paths[i] << ", ";
-        stream << "weight: " << m_translation_weights[i] << std::endl;
+        log_cout("        frame {}: {}, weight: {}", i, m_frame_paths[i],
+                m_translation_weights[i]);
     }
 }

--- a/Moco/Moco/MocoGoal/MocoTranslationTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoTranslationTrackingGoal.h
@@ -140,7 +140,7 @@ protected:
             const GoalInput& input, SimTK::Vector& cost) const override {
         cost[0] = input.integral;
     }
-    void printDescriptionImpl(std::ostream& stream = std::cout) const override;
+    void printDescriptionImpl() const override;
 
 private:
     OpenSim_DECLARE_PROPERTY(states_reference, TableProcessor,

--- a/Moco/Moco/MocoParameter.cpp
+++ b/Moco/Moco/MocoParameter.cpp
@@ -102,20 +102,25 @@ void MocoParameter::initializeOnModel(Model& model) const {
                 Exception, "Must specify a property element for "
                 "non-scalar propeties.");
             OPENSIM_THROW_IF_FRMOBJ(get_property_element() < 0, Exception,
-                format("Expected property element to be non-negative, "
-                       "but %i was provided.", get_property_element()));
+                    fmt::format("Expected property element to be non-negative, "
+                                "but {} was provided.",
+                            get_property_element()));
             if (dynamic_cast<Property<SimTK::Vec3>*>(ap)) {
                 OPENSIM_THROW_IF_FRMOBJ(get_property_element() > 2, Exception,
-                        format("The property element for a Vec3 property must "
-                               "be between 0 and 2, but the value %i was "
-                               "provided.", get_property_element()));
+                        fmt::format(
+                                "The property element for a Vec3 property must "
+                                "be between 0 and 2, but the value {} was "
+                                "provided.",
+                                get_property_element()));
                 m_data_type = Type_Vec3;
             }
             else if (dynamic_cast<Property<SimTK::Vec6>*>(ap)) {
                 OPENSIM_THROW_IF_FRMOBJ(get_property_element() > 5, Exception,
-                        format("The property element for a Vec6 property must "
-                               "be between 0 and 5, but the value %i was "
-                               "provided.", get_property_element()));
+                        fmt::format(
+                                "The property element for a Vec6 property must "
+                                "be between 0 and 5, but the value {} was "
+                                "provided.",
+                                get_property_element()));
                 m_data_type = Type_Vec6;
             }
             else {

--- a/Moco/Moco/MocoParameter.cpp
+++ b/Moco/Moco/MocoParameter.cpp
@@ -133,28 +133,21 @@ void MocoParameter::initializeOnModel(Model& model) const {
     }
 }
 
-void MocoParameter::printDescription(std::ostream& stream) const {
-    stream << getName();
-    stream << ". model property name: " << getPropertyName();
-    stream << ". component paths: ";
+void MocoParameter::printDescription() const {
     const std::vector<std::string> componentPaths = getComponentPaths();
-    for (int i = 0; i < (int)componentPaths.size(); ++i) {
-        stream << componentPaths[i];
-        if (i < (int)componentPaths.size()-1) {
-           stream << ", ";
-        } else {
-           stream << ". ";
-        }   
-    }
-    stream << "property element: ";
+
+    std::string propertyElementStr;
     if (getProperty_property_element().empty()) {
-        stream << "n/a";
+        propertyElementStr = "n/a";
     } else {
-        stream << getProperty_property_element().getValue();
+        propertyElementStr =
+                fmt::format("{}", getProperty_property_element().getValue());
     }
-    stream << ". bounds: ";
-    getBounds().printDescription(stream);
-    stream << std::endl;
+
+    log_cout("  {}. model property name: {}. component paths: {}. "
+             "property element: {}. bounds: {}",
+            getName(), getPropertyName(), fmt::join(componentPaths, ", "),
+            propertyElementStr, getBounds());
 }
 
 void MocoParameter::applyParameterToModelProperties(const double& value) const {

--- a/Moco/Moco/MocoParameter.h
+++ b/Moco/Moco/MocoParameter.h
@@ -149,7 +149,7 @@ public:
 
     /// Print the name, property name, component paths, property element (if it
     /// exists), and bounds for this parameter.
-    void printDescription(std::ostream& stream = std::cout) const;
+    void printDescription() const;
 
 private:
     OpenSim_DECLARE_UNNAMED_PROPERTY(MocoBounds,

--- a/Moco/Moco/MocoProblem.cpp
+++ b/Moco/Moco/MocoProblem.cpp
@@ -73,15 +73,13 @@ void MocoPhase::printStateNamesWithSubstring(const std::string& substring) {
         }
     }
     if (foundNames.size() > 0) {
-        std::cout << "State name(s) found matching substring '" << substring
-                  << "':" << std::endl;
-        for (std::string iname : foundNames) {
-            std::cout << iname << std::endl;
+        log_cout("State name(s) found matching substring '{}':", substring);
+        for (const auto& name : foundNames) {
+            log_cout(name);
         }
     } else {
-        std::cout << "No state names found matching substring '" << substring
-                  << "'." << std::endl;
-    };
+        log_cout("No state names found matching substring '{}'.", substring);
+    }
 }
 void MocoPhase::setStateInfo(const std::string& name, const MocoBounds& bounds,
         const MocoInitialBounds& initial, const MocoFinalBounds& final) {
@@ -115,14 +113,12 @@ void MocoPhase::printControlNamesWithSubstring(const std::string& substring) {
         }
     }
     if (foundNames.size() > 0) {
-        std::cout << "Control name(s) found matching substring '" << substring
-                  << "':" << std::endl;
-        for (std::string iname : foundNames) {
-            std::cout << iname << std::endl;
+        log_cout("Control name(s) found matching substring '{}':", substring);
+        for (const auto& name : foundNames) {
+            log_cout(name);
         }
     } else {
-        std::cout << "No control names found matching substring '" << substring
-                  << "'." << std::endl;
+        log_cout("No control names found matching substring '{}'.", substring);
     }
 }
 void MocoPhase::setControlInfo(const std::string& name,
@@ -157,7 +153,7 @@ const MocoVariableInfo& MocoPhase::getStateInfo(const std::string& name) const {
 
     int idx = getProperty_state_infos().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No info available for state '%s'.", name));
+            fmt::format("No info available for state '{}'.", name));
     return get_state_infos(idx);
 }
 const MocoVariableInfo& MocoPhase::getControlInfo(
@@ -165,35 +161,35 @@ const MocoVariableInfo& MocoPhase::getControlInfo(
 
     int idx = getProperty_control_infos().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No info available for control '%s'.", name));
+            fmt::format("No info available for control '{}'.", name));
     return get_control_infos(idx);
 }
 const MocoParameter& MocoPhase::getParameter(const std::string& name) const {
 
     int idx = getProperty_parameters().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No parameter with name '%s' found.", name));
+            fmt::format("No parameter with name '{}' found.", name));
     return get_parameters(idx);
 }
 MocoParameter& MocoPhase::updParameter(const std::string& name) {
 
     int idx = getProperty_parameters().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No parameter with name '%s' found.", name));
+            fmt::format("No parameter with name '{}' found.", name));
     return upd_parameters(idx);
 }
 const MocoGoal& MocoPhase::getGoal(const std::string& name) const {
 
     int idx = getProperty_goals().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No goal with name '%s' found.", name));
+            fmt::format("No goal with name '{}' found.", name));
     return get_goals(idx);
 }
 MocoGoal& MocoPhase::updGoal(const std::string& name) {
 
     int idx = updProperty_goals().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No goal with name '%s' found.", name));
+            fmt::format("No goal with name '{}' found.", name));
     return upd_goals(idx);
 }
 const MocoPathConstraint& MocoPhase::getPathConstraint(
@@ -201,14 +197,14 @@ const MocoPathConstraint& MocoPhase::getPathConstraint(
 
     int idx = getProperty_path_constraints().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No path constraint with name '%s' found.", name));
+            fmt::format("No path constraint with name '{}' found.", name));
     return get_path_constraints(idx);
 }
 MocoPathConstraint& MocoPhase::updPathConstraint(const std::string& name) {
 
     int idx = updProperty_path_constraints().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            format("No path constraint with name '%s' found.", name));
+            fmt::format("No path constraint with name '{}' found.", name));
     return upd_path_constraints(idx);
 }
 

--- a/Moco/Moco/MocoProblem.h
+++ b/Moco/Moco/MocoProblem.h
@@ -149,7 +149,7 @@ public:
             const MocoBounds& bounds, const MocoInitialBounds& init = {},
             const MocoFinalBounds& final = {});
     /// Find and print the names of all control variables containing a substring.
-    void printControlNamesWithSubstring (const std::string& name);
+    void printControlNamesWithSubstring(const std::string& name);
     /// Set information about a single control variable in this phase.
     /// Similar to setStateInfo(). The name for a control is the path to the
     /// associated actuator (e.g., "/forceset/soleus_r"). If setting a control

--- a/Moco/Moco/MocoProblemRep.cpp
+++ b/Moco/Moco/MocoProblemRep.cpp
@@ -56,7 +56,7 @@ void MocoProblemRep::initialize() {
     m_implicit_residual_refs.clear();
 
     if (!getTimeInitialBounds().isSet() && !getTimeFinalBounds().isSet()) {
-        std::cout << "Warning: no time bounds set." << std::endl;
+        log_warn("No time bounds set.");
     }
 
     const auto& ph0 = m_problem->getPhase(0);
@@ -194,21 +194,21 @@ void MocoProblemRep::initialize() {
             // TODO how to name multiplier variables?
             std::vector<MocoVariableInfo> multInfos;
             for (int i = 0; i < mp; ++i) {
-                std::string name = format("cid%i_p%i", cid, i);
+                std::string name = fmt::format("cid{}_p{}", cid, i);
                 kc_perr_names.push_back(name);
                 MocoVariableInfo info("lambda_" + name, multBounds,
                         multInitBounds, multFinalBounds);
                 multInfos.push_back(info);
             }
             for (int i = 0; i < mv; ++i) {
-                std::string name = format("cid%i_v%i", cid, i);
+                std::string name = fmt::format("cid{}_v{}", cid, i);
                 MocoVariableInfo info("lambda_" + name, multBounds,
                         multInitBounds, multFinalBounds);
                 kc_verr_names.push_back(name);
                 multInfos.push_back(info);
             }
             for (int i = 0; i < ma; ++i) {
-                std::string name = format("cid%i_a%i", cid, i);
+                std::string name = fmt::format("cid{}_a{}", cid, i);
                 MocoVariableInfo info("lambda_" + name, multBounds,
                         multInitBounds, multFinalBounds);
                 kc_aerr_names.push_back(name);
@@ -279,7 +279,7 @@ void MocoProblemRep::initialize() {
     for (int i = 0; i < ph0.getProperty_state_infos().size(); ++i) {
         const auto& name = ph0.get_state_infos(i).getName();
         OPENSIM_THROW_IF(stateNames.findIndex(name) == -1, Exception,
-                format("State info provided for nonexistent state '%s'.",
+                fmt::format("State info provided for nonexistent state '{}'.",
                         name));
     }
 
@@ -299,9 +299,8 @@ void MocoProblemRep::initialize() {
         for (const auto& output : outputsBound) {
             const auto nameStart = output->getName().find("_") + 1;
             const auto stateName = output->getName().substr(nameStart);
-            const auto statePath = format("%s/%s",
-                    component.getAbsolutePathString(),
-                    stateName);
+            const auto statePath = fmt::format(
+                    "{}/{}", component.getAbsolutePathString(), stateName);
             // If this is indeed a state and no info has been provided for it,
             // use the state bounds from the output.
             if (stateNames.findIndex(statePath) != -1) {
@@ -368,8 +367,8 @@ void MocoProblemRep::initialize() {
         const auto& name = ph0.get_control_infos(i).getName();
         auto it = std::find(controlNames.begin(), controlNames.end(), name);
         OPENSIM_THROW_IF(it == controlNames.end(), Exception,
-                format("Control info provided for nonexistent or disabled "
-                       "actuator '%s'.",
+                fmt::format("Control info provided for nonexistent or disabled "
+                            "actuator '{}'.",
                         name));
     }
 
@@ -459,7 +458,7 @@ void MocoProblemRep::initialize() {
         OPENSIM_THROW_IF(param.getName().empty(), Exception,
                 "All parameters must have a name.");
         OPENSIM_THROW_IF(paramNames.count(param.getName()), Exception,
-                format("A parameter with name '%s' already exists.",
+                fmt::format("A parameter with name '{}' already exists.",
                         param.getName()));
         paramNames.insert(param.getName());
         m_parameters[i] = std::unique_ptr<MocoParameter>(param.clone());
@@ -481,7 +480,7 @@ void MocoProblemRep::initialize() {
         OPENSIM_THROW_IF(goal.getName().empty(), Exception,
                 "All goals must have a name.");
         OPENSIM_THROW_IF(goalNames.count(goal.getName()), Exception,
-                format("A goal with name '%s' already exists.",
+                fmt::format("A goal with name '{}' already exists.",
                         goal.getName()));
         goalNames.insert(goal.getName());
         if (goal.getEnabled()) {
@@ -509,7 +508,7 @@ void MocoProblemRep::initialize() {
         OPENSIM_THROW_IF(pc.getName().empty(), Exception,
                 "All path constraints must have a name.");
         OPENSIM_THROW_IF(pcNames.count(pc.getName()), Exception,
-                format("A path constraint with name '%s' already exists.",
+                fmt::format("A path constraint with name '{}' already exists.",
                         pc.getName()));
         pcNames.insert(pc.getName());
         m_path_constraints[i] = std::unique_ptr<MocoPathConstraint>(pc.clone());
@@ -626,13 +625,13 @@ std::vector<std::string> MocoProblemRep::createPathConstraintNames() const {
 const MocoVariableInfo& MocoProblemRep::getStateInfo(
         const std::string& name) const {
     OPENSIM_THROW_IF(m_state_infos.count(name) == 0, Exception,
-            format("No info available for state '%s'.", name));
+            fmt::format("No info available for state '{}'.", name));
     return m_state_infos.at(name);
 }
 const MocoVariableInfo& MocoProblemRep::getControlInfo(
         const std::string& name) const {
     OPENSIM_THROW_IF(m_control_infos.count(name) == 0, Exception,
-            format("No info available for control '%s'.", name));
+            fmt::format("No info available for control '{}'.", name));
     return m_control_infos.at(name);
 }
 const MocoParameter& MocoProblemRep::getParameter(
@@ -642,14 +641,15 @@ const MocoParameter& MocoProblemRep::getParameter(
         if (param->getName() == name) { return *param.get(); }
     }
     OPENSIM_THROW(
-            Exception, format("No parameter with name '%s' found.", name));
+            Exception, fmt::format("No parameter with name '{}' found.", name));
 }
 const MocoGoal& MocoProblemRep::getCost(const std::string& name) const {
 
     for (const auto& c : m_costs) {
         if (c->getName() == name) { return *c.get(); }
     }
-    OPENSIM_THROW(Exception, format("No cost with name '%s' found.", name));
+    OPENSIM_THROW(
+            Exception, fmt::format("No cost with name '{}' found.", name));
 }
 const MocoGoal& MocoProblemRep::getCostByIndex(int index) const {
     return *m_costs[index];
@@ -661,7 +661,7 @@ const MocoGoal& MocoProblemRep::getEndpointConstraint(
         if (c->getName() == name) { return *c.get(); }
     }
     OPENSIM_THROW(Exception,
-            format("No endpoint constraint with name '%s' found.", name));
+            fmt::format("No endpoint constraint with name '{}' found.", name));
 }
 const MocoGoal& MocoProblemRep::getEndpointConstraintByIndex(int index) const {
     return *m_endpoint_constraints[index];
@@ -673,7 +673,7 @@ const MocoPathConstraint& MocoProblemRep::getPathConstraint(
         if (pc->getName() == name) { return *pc.get(); }
     }
     OPENSIM_THROW(Exception,
-            format("No path constraint with name '%s' found.", name));
+            fmt::format("No path constraint with name '{}' found.", name));
 }
 const MocoPathConstraint& MocoProblemRep::getPathConstraintByIndex(
         int index) const {
@@ -688,7 +688,7 @@ const MocoKinematicConstraint& MocoProblemRep::getKinematicConstraint(
         if (kc.getConstraintInfo().getName() == name) { return kc; }
     }
     OPENSIM_THROW(Exception,
-            format("No kinematic constraint with name '%s' found.", name));
+            fmt::format("No kinematic constraint with name '{}' found.", name));
 }
 const std::vector<MocoVariableInfo>& MocoProblemRep::getMultiplierInfos(
         const std::string& kinematicConstraintInfoName) const {
@@ -697,9 +697,9 @@ const std::vector<MocoVariableInfo>& MocoProblemRep::getMultiplierInfos(
     if (search != m_multiplier_infos_map.end()) {
         return m_multiplier_infos_map.at(kinematicConstraintInfoName);
     } else {
-        OPENSIM_THROW(Exception, format("No variable infos for kinematic "
-                                        "constraint info with "
-                                        "name '%s' found.",
+        OPENSIM_THROW(Exception, fmt::format("No variable infos for kinematic "
+                                             "constraint info with "
+                                             "name '{}' found.",
                                          kinematicConstraintInfoName));
     }
 }
@@ -709,8 +709,8 @@ void MocoProblemRep::applyParametersToModelProperties(
         bool initSystemAndDisableConstraints) const {
     OPENSIM_THROW_IF(parameterValues.size() != (int)m_parameters.size(),
             Exception,
-            format("There are %i parameters in "
-                   "this MocoProblem, but %i values were provided.",
+            fmt::format("There are {} parameters in "
+                        "this MocoProblem, but {} values were provided.",
                     m_parameters.size(), parameterValues.size()));
     for (int i = 0; i < (int)m_parameters.size(); ++i) {
         m_parameters[i]->applyParameterToModelProperties(parameterValues(i));

--- a/Moco/Moco/MocoProblemRep.cpp
+++ b/Moco/Moco/MocoProblemRep.cpp
@@ -763,85 +763,53 @@ void MocoProblemRep::applyParametersToModelProperties(
     }
 }
 
-void MocoProblemRep::printDescription(std::ostream& stream) const {
-    stream << "Costs:";
-    if (m_costs.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_costs.size() << ")";
-    stream << "\n";
+void MocoProblemRep::printDescription() const {
+
+    auto printHeaderLine = [&](const std::string& label, size_t size) {
+        std::stringstream ss;
+        ss << label << ": ";
+        if (size == 0) {
+            ss << "none";
+        } else {
+            ss << "(total: " << size << ")";
+        }
+        log_cout(ss.str());
+    };
+
+    printHeaderLine("Costs", m_costs.size());
     for (const auto& cost : m_costs) {
-        stream << "  ";
-        cost->printDescription(stream);
+        cost->printDescription();
     }
 
-    stream << "Endpoint constraints:";
-    if (m_endpoint_constraints.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_endpoint_constraints.size() << ")";
-    stream << "\n";
+    printHeaderLine("Endpoint constraints", m_endpoint_constraints.size());
     for (const auto& endpoint_constraint : m_endpoint_constraints) {
-        stream << "  ";
-        endpoint_constraint->printDescription(stream);
+        endpoint_constraint->printDescription();
     }
 
-    stream << "Kinematic constraints:";
-    if (m_kinematic_constraints.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_kinematic_constraints.size() << ")";
-    stream << "\n";
+    printHeaderLine("Kinematic constraints", m_kinematic_constraints.size());
     for (int i = 0; i < (int)m_kinematic_constraints.size(); ++i) {
-        stream << "  ";
-        m_kinematic_constraints[i].getConstraintInfo().printDescription(stream);
+        m_kinematic_constraints[i].getConstraintInfo().printDescription();
     }
 
-    stream << "Path constraints:";
-    if (m_path_constraints.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_path_constraints.size() << ")";
-    stream << "\n";
+    printHeaderLine("Path constraints", m_path_constraints.size());
     for (const auto& pc : m_path_constraints) {
-        stream << "  ";
-        pc->getConstraintInfo().printDescription(stream);
+        pc->getConstraintInfo().printDescription();
     }
 
-    stream << "States:";
-    if (m_state_infos.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_state_infos.size() << ")";
-    stream << "\n";
+    printHeaderLine("States", m_state_infos.size());
     // TODO want to loop through the model's state variables and controls,
     // not just the infos.
     for (const auto& info : m_state_infos) {
-        stream << "  ";
-        info.second.printDescription(stream);
+        info.second.printDescription();
     }
 
-    stream << "Controls:";
-    if (m_control_infos.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_control_infos.size() << "):";
-    stream << "\n";
+    printHeaderLine("Controls", m_control_infos.size());
     for (const auto& info : m_control_infos) {
-        stream << "  ";
-        info.second.printDescription(stream);
+        info.second.printDescription();
     }
 
-    stream << "Parameters:";
-    if (m_parameters.empty())
-        stream << " none";
-    else
-        stream << " (total: " << m_parameters.size() << "):";
-    stream << "\n";
+    printHeaderLine("Parameters", m_parameters.size());
     for (const auto& param : m_parameters) {
-        stream << "  ";
-        param->printDescription(stream);
+        param->printDescription();
     }
-
-    stream.flush();
 }

--- a/Moco/Moco/MocoProblemRep.h
+++ b/Moco/Moco/MocoProblemRep.h
@@ -219,9 +219,8 @@ public:
     }
 
     /// Print a description of this problem, including costs and variable
-    /// bounds. By default, the description is printed to the console (cout),
-    /// but you can provide your own stream.
-    void printDescription(std::ostream& stream = std::cout) const;
+    /// bounds. Printing is done using OpenSim::log_cout().
+    void printDescription() const;
 
     /// @name Interface for solvers
     /// These functions are for use by MocoSolver%s, but can also be called

--- a/Moco/Moco/MocoSolver.cpp
+++ b/Moco/Moco/MocoSolver.cpp
@@ -28,9 +28,9 @@ MocoTrajectory MocoSolver::createGuessTimeStepping() const {
     const auto& initialTime = probrep.getTimeInitialBounds().getUpper();
     const auto& finalTime = probrep.getTimeFinalBounds().getLower();
     OPENSIM_THROW_IF_FRMOBJ(finalTime <= initialTime, Exception,
-            format("Expected lower bound on final time to be greater than "
-                   "upper bound on initial time, but "
-                   "final_time.lower: %g; initial_time.upper: %g.",
+            fmt::format("Expected lower bound on final time to be greater than "
+                        "upper bound on initial time, but "
+                        "final_time.lower: {}; initial_time.upper: {}.",
                     finalTime, initialTime));
     Model model(probrep.getModelBase());
 

--- a/Moco/Moco/MocoStudy.cpp
+++ b/Moco/Moco/MocoStudy.cpp
@@ -80,18 +80,7 @@ MocoSolution MocoStudy::solve() const {
     // TODO avoid const_cast.
     const_cast<Self*>(this)->initSolverInternal();
 
-    // Temporarily disable printing of negative muscle force warnings so the
-    // output stream isn't flooded while computing finite differences.
-    int oldDebugLevel = Object::getDebugLevel();
-    Object::setDebugLevel(-1);
-    MocoSolution solution;
-    try {
-        solution = get_solver().solve();
-    } catch (const Exception&) {
-        Object::setDebugLevel(oldDebugLevel);
-        throw;
-    }
-    Object::setDebugLevel(oldDebugLevel);
+    MocoSolution solution = get_solver().solve();
 
     bool originallySealed = solution.isSealed();
     if (get_write_solution() != "false") {

--- a/Moco/Moco/MocoStudy.cpp
+++ b/Moco/Moco/MocoStudy.cpp
@@ -104,8 +104,7 @@ MocoSolution MocoStudy::solve() const {
         try {
             solution.write(filename);
         } catch (const TimestampGreaterThanEqualToNext&) {
-            std::cout << "Could not write solution to file...skipping."
-                      << std::endl;
+            log_warn("Could not write solution to file...skipping.");
         }
         if (originallySealed) solution.seal();
     }

--- a/Moco/Moco/MocoTool.cpp
+++ b/Moco/Moco/MocoTool.cpp
@@ -36,8 +36,8 @@ void MocoTool::updateTimeInfo(const std::string& dataLabel,
     double final;
     if (!getProperty_initial_time().empty()) {
         OPENSIM_THROW_IF_FRMOBJ(get_initial_time() < dataInitial, Exception,
-                format("Provided initial time of %g is less than what is "
-                       "available from %s data, which starts at %g.",
+                fmt::format("Provided initial time of {} is less than what is "
+                            "available from {} data, which starts at {}.",
                         get_initial_time(), dataLabel, dataInitial));
         initial = get_initial_time();
     } else {
@@ -45,8 +45,8 @@ void MocoTool::updateTimeInfo(const std::string& dataLabel,
     }
     if (!getProperty_final_time().empty()) {
         OPENSIM_THROW_IF_FRMOBJ(get_final_time() > dataFinal, Exception,
-                format("Provided final time of %g is greater than what "
-                       "is available from %s data, which ends at %g.",
+                fmt::format("Provided final time of {} is greater than what "
+                            "is available from {} data, which ends at {}.",
                         get_final_time(), dataLabel, dataFinal));
         final = get_final_time();
     } else {
@@ -54,11 +54,11 @@ void MocoTool::updateTimeInfo(const std::string& dataLabel,
     }
 
     OPENSIM_THROW_IF_FRMOBJ(final < initial, Exception,
-            format("Initial time of %g is greater than final time of %g.",
+            fmt::format("Initial time of {} is greater than final time of {}.",
                     initial, final));
 
     OPENSIM_THROW_IF_FRMOBJ(get_mesh_interval() <= 0, Exception,
-            format("Expected mesh_interval to be positive but got %f.",
+            fmt::format("Expected mesh_interval to be positive but got {}.",
                     get_mesh_interval()));
 
     info.initial = initial;

--- a/Moco/Moco/MocoTrack.cpp
+++ b/Moco/Moco/MocoTrack.cpp
@@ -86,8 +86,8 @@ MocoStudy MocoTrack::initialize() {
     // ----------------------------
     if (get_minimize_control_effort()) {
         OPENSIM_THROW_IF(get_control_effort_weight() < 0, Exception,
-                format("Expected a non-negative control effort weight, but "
-                       "got a weight with value %d.",
+                fmt::format("Expected a non-negative control effort weight, "
+                            "but got a weight with value {}.",
                         get_control_effort_weight()));
 
         auto* effort = problem.addGoal<MocoControlGoal>("control_effort");
@@ -280,9 +280,8 @@ void MocoTrack::applyStatesToGuess(
             guess.setState(label, col);
         } else {
             OPENSIM_THROW_IF(!get_allow_unused_references(), Exception,
-                    format("Tried to apply data for state '%s' to guess, but "
-                           "this "
-                           "state does not exist in the model.",
+                    fmt::format("Tried to apply data for state '{}' to guess, "
+                                "but this state does not exist in the model.",
                             label));
         }
     }

--- a/Moco/Moco/MocoTrajectory.cpp
+++ b/Moco/Moco/MocoTrajectory.cpp
@@ -1390,7 +1390,6 @@ void MocoSolution::printObjectiveBreakdown() const {
     for (const auto& entry : m_objectiveBreakdown) {
         log_cout("{}: {}", entry.first, entry.second);
     }
-    std::cout << std::flush;
 }
 
 void MocoSolution::convertToTableImpl(TimeSeriesTable& table) const {

--- a/Moco/Moco/MocoTrajectory.cpp
+++ b/Moco/Moco/MocoTrajectory.cpp
@@ -985,16 +985,16 @@ bool MocoTrajectory::isCompatible(const MocoProblemRep& mp,
     // Slack variables might be solver dependent, so we can't include them in
     // the compatibility check.
 
-    const int debugLevel = Object::getDebugLevel();
-
-    auto compare = [&throwOnError, &debugLevel](
+    auto compare = [&throwOnError](
             std::string varType, std::vector<std::string> trajNames,
             std::vector<std::string> probNames,
             std::string message = "") {
         std::sort(trajNames.begin(), trajNames.end());
         std::sort(probNames.begin(), probNames.end());
         if (trajNames == probNames) return true;
-        if (!throwOnError && debugLevel <= 0) return false;
+        if (!throwOnError && !Logger::shouldLog(Logger::Level::Debug)) {
+            return false;
+        }
 
         int sum = (int)trajNames.size() + (int)probNames.size();
 
@@ -1033,11 +1033,11 @@ bool MocoTrajectory::isCompatible(const MocoProblemRep& mp,
         }
         ss << message << "\n";
 
-        if (debugLevel <= 0) {
+        if (throwOnError) {
             throw Exception(__FILE__, __LINE__,
                     "MocoTrajectory::isCompatible()", ss.str());
         }
-        std::cout << ss.str() << std::flush;
+        log_debug(ss.str());
         return false;
     };
 

--- a/Moco/Moco/MocoTrajectory.cpp
+++ b/Moco/Moco/MocoTrajectory.cpp
@@ -74,21 +74,22 @@ MocoTrajectory::MocoTrajectory(const SimTK::Vector& time,
             Exception, "Inconsistent number of multipliers.");
     if (m_states.ncol()) {
         OPENSIM_THROW_IF(time.size() != m_states.nrow(), Exception,
-                format("Expected states to have %i rows but it has %i.",
+                fmt::format("Expected states to have {} rows but it has {}.",
                         time.size(), m_states.nrow()));
     } else {
         m_states.resize(m_time.size(), 0);
     }
     if (m_controls.ncol()) {
         OPENSIM_THROW_IF(time.size() != m_controls.nrow(), Exception,
-                format("Expected controls to have %i rows but it has %i.",
+                fmt::format("Expected controls to have {} rows but it has {}.",
                         time.size(), m_controls.nrow()));
     } else {
         m_controls.resize(m_time.size(), 0);
     }
     if (m_multipliers.ncol()) {
         OPENSIM_THROW_IF(time.size() != m_multipliers.nrow(), Exception,
-                format("Expected multipliers to have %i rows but it has %i.",
+                fmt::format("Expected multipliers to have {} rows but it has "
+                            "{}.",
                         time.size(), m_multipliers.nrow()));
     } else {
         m_multipliers.resize(m_time.size(), 0);
@@ -152,7 +153,7 @@ MocoTrajectory::MocoTrajectory(const SimTK::Vector& time,
 void MocoTrajectory::setTime(const SimTK::Vector& time) {
     ensureUnsealed();
     OPENSIM_THROW_IF(time.size() != m_time.size(), Exception,
-            format("Expected %i times but got %i.", m_time.size(),
+            fmt::format("Expected {} times but got {}.", m_time.size(),
                     time.size()));
     m_time = time;
 }
@@ -161,12 +162,12 @@ void MocoTrajectory::setState(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_states.nrow(), Exception,
-            format("For state %s, expected %i elements but got %i.", name,
+            fmt::format("For state {}, expected {} elements but got {}.", name,
                     m_states.nrow(), trajectory.size()));
 
     auto it = std::find(m_state_names.cbegin(), m_state_names.cend(), name);
     OPENSIM_THROW_IF(it == m_state_names.cend(), Exception,
-            format("Cannot find state named %s.", name));
+            fmt::format("Cannot find state named {}.", name));
     int index = (int)std::distance(m_state_names.cbegin(), it);
     m_states.updCol(index) = trajectory;
 }
@@ -175,12 +176,12 @@ void MocoTrajectory::setControl(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_controls.nrow(), Exception,
-            format("For control %s, expected %i elements but got %i.", name,
-                    m_controls.nrow(), trajectory.size()));
+            fmt::format("For control {}, expected {} elements but got {}.",
+                    name, m_controls.nrow(), trajectory.size()));
 
     auto it = std::find(m_control_names.cbegin(), m_control_names.cend(), name);
     OPENSIM_THROW_IF(it == m_control_names.cend(), Exception,
-            format("Cannot find control named %s.", name));
+            fmt::format("Cannot find control named {}.", name));
     int index = (int)std::distance(m_control_names.cbegin(), it);
     m_controls.updCol(index) = trajectory;
 }
@@ -189,13 +190,13 @@ void MocoTrajectory::setMultiplier(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_multipliers.nrow(), Exception,
-            format("For multiplier %s, expected %i elements but got %i.", name,
-                    m_multipliers.nrow(), trajectory.size()));
+            fmt::format("For multiplier {}, expected {} elements but got {}.",
+                    name, m_multipliers.nrow(), trajectory.size()));
 
     auto it = std::find(
             m_multiplier_names.cbegin(), m_multiplier_names.cend(), name);
     OPENSIM_THROW_IF(it == m_multiplier_names.cend(), Exception,
-            format("Cannot find multiplier named %s.", name));
+            fmt::format("Cannot find multiplier named {}.", name));
     int index = (int)std::distance(m_multiplier_names.cbegin(), it);
     m_multipliers.updCol(index) = trajectory;
 }
@@ -204,13 +205,13 @@ void MocoTrajectory::setDerivative(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_derivatives.nrow(), Exception,
-            format("For derivative %s, expected %i elements but got %i.", name,
-                    m_derivatives.nrow(), trajectory.size()));
+            fmt::format("For derivative {}, expected {} elements but got {}.",
+                    name, m_derivatives.nrow(), trajectory.size()));
 
     auto it = std::find(
             m_derivative_names.cbegin(), m_derivative_names.cend(), name);
     OPENSIM_THROW_IF(it == m_derivative_names.cend(), Exception,
-            format("Cannot find derivative named %s.", name));
+            fmt::format("Cannot find derivative named {}.", name));
     int index = (int)std::distance(m_derivative_names.cbegin(), it);
     m_derivatives.updCol(index) = trajectory;
 
@@ -221,12 +222,12 @@ void MocoTrajectory::setSlack(
     ensureUnsealed();
 
     OPENSIM_THROW_IF(trajectory.size() != m_slacks.nrow(), Exception,
-            format("For slack %s, expected %i elements but got %i.", name,
+            fmt::format("For slack {}, expected {} elements but got {}.", name,
                     m_slacks.nrow(), trajectory.size()));
 
     auto it = std::find(m_slack_names.cbegin(), m_slack_names.cend(), name);
     OPENSIM_THROW_IF(it == m_slack_names.cend(), Exception,
-            format("Cannot find slack named %s.", name));
+            fmt::format("Cannot find slack named {}.", name));
     int index = (int)std::distance(m_slack_names.cbegin(), it);
     m_slacks.updCol(index) = trajectory;
 }
@@ -238,8 +239,9 @@ void MocoTrajectory::appendSlack(
     OPENSIM_THROW_IF(m_time.nrow() == 0, Exception,
             "The time vector must be set before adding slack variables.");
     OPENSIM_THROW_IF(trajectory.size() != m_time.nrow(), Exception,
-            format("Attempted to add slack %s of length %i, but it is "
-                   "incompatible with the time vector, which has length %i.",
+            fmt::format("Attempted to add slack {} of length {}, but it is "
+                        "incompatible with the time vector, which has length "
+                        "{}.",
                     name, trajectory.size(), m_time.nrow()));
 
     m_slack_names.push_back(name);
@@ -254,7 +256,7 @@ void MocoTrajectory::setParameter(
     auto it = std::find(
             m_parameter_names.cbegin(), m_parameter_names.cend(), name);
     OPENSIM_THROW_IF(it == m_parameter_names.cend(), Exception,
-            format("Cannot find parameter named %s.", name));
+            fmt::format("Cannot find parameter named {}.", name));
     int index = (int)std::distance(m_parameter_names.cbegin(), it);
     m_parameters.updElt(0, index) = value;
 }
@@ -273,8 +275,8 @@ void MocoTrajectory::setStatesTrajectory(const TimeSeriesTable& states,
         for (const auto& trajectory_state : m_state_names) {
             OPENSIM_THROW_IF(find(labels, trajectory_state) == labels.end(),
                     Exception,
-                    format("Expected table to contain column '%s'; consider "
-                           "setting allowMissingColumns to true.",
+                    fmt::format("Expected table to contain column '{}'; "
+                                "consider setting allowMissingColumns to true.",
                             trajectory_state));
         }
     }
@@ -286,9 +288,9 @@ void MocoTrajectory::setStatesTrajectory(const TimeSeriesTable& states,
         } else {
             if (!allowExtraColumns) {
                 OPENSIM_THROW(Exception,
-                        format("Column '%s' is not a state in the "
-                               "trajectory; consider setting allowExtraColumns to "
-                               "true.",
+                        fmt::format("Column '{}' is not a state in the "
+                                    "trajectory; consider setting "
+                                    "allowExtraColumns to true.",
                                 label));
             }
         }
@@ -506,7 +508,7 @@ SimTK::VectorView MocoTrajectory::getState(const std::string& name) const {
     ensureUnsealed();
     auto it = std::find(m_state_names.cbegin(), m_state_names.cend(), name);
     OPENSIM_THROW_IF(it == m_state_names.cend(), Exception,
-            format("Cannot find state named %s.", name));
+            fmt::format("Cannot find state named {}.", name));
     int index = (int)std::distance(m_state_names.cbegin(), it);
     return m_states.col(index);
 }
@@ -514,7 +516,7 @@ SimTK::VectorView MocoTrajectory::getControl(const std::string& name) const {
     ensureUnsealed();
     auto it = std::find(m_control_names.cbegin(), m_control_names.cend(), name);
     OPENSIM_THROW_IF(it == m_control_names.cend(), Exception,
-            format("Cannot find control named %s.", name));
+            fmt::format("Cannot find control named {}.", name));
     int index = (int)std::distance(m_control_names.cbegin(), it);
     return m_controls.col(index);
 }
@@ -523,7 +525,7 @@ SimTK::VectorView MocoTrajectory::getMultiplier(const std::string& name) const {
     auto it = std::find(
             m_multiplier_names.cbegin(), m_multiplier_names.cend(), name);
     OPENSIM_THROW_IF(it == m_multiplier_names.cend(), Exception,
-            format("Cannot find multiplier named %s.", name));
+            fmt::format("Cannot find multiplier named {}.", name));
     int index = (int)std::distance(m_multiplier_names.cbegin(), it);
     return m_multipliers.col(index);
 }
@@ -532,7 +534,7 @@ SimTK::VectorView MocoTrajectory::getDerivative(const std::string& name) const {
     auto it = std::find(
             m_derivative_names.cbegin(), m_derivative_names.cend(), name);
     OPENSIM_THROW_IF(it == m_derivative_names.cend(), Exception,
-            format("Cannot find derivative named %s.", name));
+            fmt::format("Cannot find derivative named {}.", name));
     int index = (int)std::distance(m_derivative_names.cbegin(), it);
     return m_derivatives.col(index);
 }
@@ -540,7 +542,7 @@ SimTK::VectorView MocoTrajectory::getSlack(const std::string& name) const {
     ensureUnsealed();
     auto it = std::find(m_slack_names.cbegin(), m_slack_names.cend(), name);
     OPENSIM_THROW_IF(it == m_slack_names.cend(), Exception,
-            format("Cannot find slack named %s.", name));
+            fmt::format("Cannot find slack named {}.", name));
     int index = (int)std::distance(m_slack_names.cbegin(), it);
     return m_slacks.col(index);
 }
@@ -549,7 +551,7 @@ const SimTK::Real& MocoTrajectory::getParameter(const std::string& name) const {
     auto it = std::find(
             m_parameter_names.cbegin(), m_parameter_names.cend(), name);
     OPENSIM_THROW_IF(it == m_parameter_names.cend(), Exception,
-            format("Cannot find parameter named %s.", name));
+            fmt::format("Cannot find parameter named {}.", name));
     int index = (int)std::distance(m_parameter_names.cbegin(), it);
     return m_parameters.getElt(0, index);
 }
@@ -585,18 +587,18 @@ void MocoTrajectory::resample(SimTK::Vector time) {
     OPENSIM_THROW_IF(m_time.size() < 2, Exception,
             "Cannot resample if number of times is 0 or 1.");
     OPENSIM_THROW_IF(time[0] < m_time[0], Exception,
-            format("New initial time (%f) cannot be less than existing initial "
-                   "time (%f)",
+            fmt::format("New initial time ({}) cannot be less than existing "
+                        "initial time ({})",
                     time[0], m_time[0]));
     OPENSIM_THROW_IF(time[time.size() - 1] > m_time[m_time.size() - 1],
             Exception,
-            format("New final time (%f) cannot be less than existing final "
-                   "time (%f)",
+            fmt::format("New final time ({}) cannot be less than existing "
+                        "final time ({})",
                     time[time.size() - 1], m_time[m_time.size() - 1]));
     for (int itime = 1; itime < time.size(); ++itime) {
         OPENSIM_THROW_IF(time[itime] < time[itime - 1], Exception,
-                format("New times must be non-decreasing, but "
-                       "time[%i] < time[%i] (%f < %f).",
+                fmt::format("New times must be non-decreasing, but "
+                            "time[{}] < time[{}] ({} < {}).",
                         itime, itime - 1, time[itime], time[itime - 1]));
     }
 
@@ -728,12 +730,13 @@ MocoTrajectory::MocoTrajectory(const std::string& filepath) {
                                      numSlacks + numParameters !=
                              (int)table.getNumColumns(),
             Exception,
-            format("Expected num_states + num_controls + num_multipliers + "
-                   "num_derivatives + num_slacks + num_parameters = "
-                   "number of columns, but "
-                   "num_states=%i, num_controls=%i, "
-                   "num_multipliers=%i, num_derivatives=%i, num_slacks=%i, "
-                   "num_parameters=%i, number of columns=%i.",
+            fmt::format(
+                    "Expected num_states + num_controls + num_multipliers + "
+                    "num_derivatives + num_slacks + num_parameters = "
+                    "number of columns, but "
+                    "num_states={}, num_controls={}, "
+                    "num_multipliers={}, num_derivatives={}, num_slacks={}, "
+                    "num_parameters={}, number of columns={}.",
                     numStates, numControls, numMultipliers, numDerivatives,
                     numSlacks, numParameters, table.getNumColumns()));
 
@@ -945,17 +948,18 @@ void MocoTrajectory::randomize(bool add, const SimTK::Random& randGen) {
     const int statesNumRows = (int)statesTrajectory.getNumRows();
     const int controlsNumRows = (int)controlsTrajectory.getNumRows();
     OPENSIM_THROW_IF(statesNumRows != controlsNumRows, Exception,
-            format("Expected statesTrajectory (%i rows) and controlsTrajectory "
-                   "(%i rows) to have the same number of rows.",
+            fmt::format("Expected statesTrajectory ({} rows) and "
+                        "controlsTrajectory ({} rows) to have the same number "
+                        "of rows.",
                     statesNumRows, controlsNumRows));
     // TODO interpolate instead of creating this error.
     for (int i = 0; i < statesNumRows; ++i) {
         const auto& statesTime = statesTrajectory.getIndependentColumn()[i];
         const auto& controlsTime = controlsTrajectory.getIndependentColumn()[i];
         OPENSIM_THROW_IF(statesTime != controlsTime, Exception,
-                format("Expected time columns of statesTrajectory and "
-                       "controlsTrajectory to match, but they differ at i = %i "
-                       "(states time: %g; controls time: %g).",
+                fmt::format("Expected time columns of statesTrajectory and "
+                            "controlsTrajectory to match, but they differ at i "
+                            "= {} (states time: {}; controls time: {}).",
                         i, statesTime, controlsTime));
     }
 
@@ -1271,8 +1275,7 @@ double MocoTrajectory::compareContinuousVariablesRMS(
     ensureUnsealed();
     for (auto kv : cols) {
         OPENSIM_THROW_IF(find(m_allowedKeys, kv.first) == m_allowedKeys.cend(),
-                Exception,
-                format("Key '%s' is not allowed.", kv.first));
+                Exception, fmt::format("Key '{}' is not allowed.", kv.first));
     }
     if (cols.size() == 0) {
         return compareContinuousVariablesRMSInternal(other);
@@ -1300,7 +1303,7 @@ double MocoTrajectory::compareContinuousVariablesRMSPattern(
         names = &m_derivative_names;
     } else {
         OPENSIM_THROW(Exception,
-                format("Column type '%s' is not allowed.", columnType));
+                fmt::format("Column type '{}' is not allowed.", columnType));
     }
     std::vector<std::string> namesToUse;
     std::regex regex(pattern);
@@ -1364,7 +1367,7 @@ double MocoSolution::getObjectiveTerm(const std::string& name) const {
         }
     }
     OPENSIM_THROW(
-            Exception, format("Objective term '%s' not found.", name));
+            Exception, fmt::format("Objective term '{}' not found.", name));
 }
 
 double MocoSolution::getObjectiveTermByIndex(int index) const {
@@ -1372,8 +1375,8 @@ double MocoSolution::getObjectiveTermByIndex(int index) const {
     OPENSIM_THROW_IF(
             index < 0, Exception, "Expected index to be non-negative.");
     OPENSIM_THROW_IF(index >= (int)m_objectiveBreakdown.size(), Exception,
-            format("Expected index (%i) to be less than the number of "
-                   "objective terms (%i).",
+            fmt::format("Expected index ({}) to be less than the number of "
+                        "objective terms ({}).",
                     index, m_objectiveBreakdown.size()));
     return m_objectiveBreakdown[index].second;
 }
@@ -1381,11 +1384,11 @@ double MocoSolution::getObjectiveTermByIndex(int index) const {
 void MocoSolution::printObjectiveBreakdown() const {
     ensureUnsealed();
     if (m_objectiveBreakdown.empty()) {
-        std::cout << "no terms or no breakdown available" << std::endl;
+        log_cout("No terms or no breakdown available");
         return;
     }
     for (const auto& entry : m_objectiveBreakdown) {
-        std::cout << entry.first << ": " << entry.second << "\n";
+        log_cout("{}: {}", entry.first, entry.second);
     }
     std::cout << std::flush;
 }

--- a/Moco/Moco/MocoTrajectory.h
+++ b/Moco/Moco/MocoTrajectory.h
@@ -510,9 +510,9 @@ public:
     /// requireAccelerations to true.
     /// To throw an exception with a detailed message if the problem is not
     /// compatible, pass throwOnError as true. To get the detailed message
-    /// without an exception, set the Object debug level to a level greater than
-    /// 0 (e.g., `Object::setDebugLevel(1)` in C++, and
-    /// `OpenSimObject.setDebugLevel(1)` in MATLAB/Python).
+    /// without an exception, set the Logger level to Debug or a more verbose
+    /// setting (e.g., `Logger::setLevel(Logger::Level::Debug)` in C++, and
+    /// `Logger.setLevel(Logger.Level_Debug)` in MATLAB/Python).
     bool isCompatible(const MocoProblemRep&, bool requireAccelerations = false,
             bool throwOnError = false) const;
     /// Check if this trajectory is numerically equal to another trajectory.

--- a/Moco/Moco/MocoTropterSolver.cpp
+++ b/Moco/Moco/MocoTropterSolver.cpp
@@ -90,10 +90,10 @@ MocoTropterSolver::createTropterSolver(
         OPENSIM_THROW_IF(get_transcription_scheme() != "hermite-simpson" &&
                                  get_enforce_constraint_derivatives(),
                 Exception,
-                format("If enforcing derivatives of model kinematic "
+                fmt::format("If enforcing derivatives of model kinematic "
                        "constraints, then the property 'transcription_scheme' "
                        "must be set to 'hermite-simpson'. "
-                       "Currently, it is set to '%s'.",
+                       "Currently, it is set to '{}'.",
                         get_transcription_scheme()));
     }
     OPENSIM_THROW_IF_FRMOBJ(
@@ -108,11 +108,9 @@ MocoTropterSolver::createTropterSolver(
                     !getProperty_exact_hessian_block_sparsity_mode().empty(),
             Exception,
             "A value for solver property 'exact_hessian_block_sparsity_mode' "
-            "was "
-            "provided, but is unused when using a 'limited-memory' Hessian "
+            "was provided, but is unused when using a 'limited-memory' Hessian "
             "approximation. Set solver property 'optim_hessian_approximation' "
-            "to "
-            "'exact' for Hessian block sparsity to take effect.");
+            "to 'exact' for Hessian block sparsity to take effect.");
     if (!getProperty_exact_hessian_block_sparsity_mode().empty()) {
         checkPropertyInSet(*this,
                 getProperty_exact_hessian_block_sparsity_mode(),
@@ -217,9 +215,8 @@ MocoTrajectory MocoTropterSolver::createGuess(const std::string& type) const {
     OPENSIM_THROW_IF_FRMOBJ(
             type != "bounds" && type != "random" && type != "time-stepping",
             Exception,
-            format("Unexpected guess type '%s'; supported types are "
-                   "'bounds', "
-                   "'random', and 'time-stepping'.",
+            fmt::format("Unexpected guess type '{}'; supported types are "
+                   "'bounds', 'random', and 'time-stepping'.",
                     type));
 
     if (type == "time-stepping") { return createGuessTimeStepping(); }
@@ -301,8 +298,7 @@ void MocoTropterSolver::printOptimizationSolverOptions(std::string solver) {
     if (solver == "ipopt") {
         tropter::optimization::IPOPTSolver::print_available_options();
     } else {
-        std::cout << "No info available for " << solver << " options."
-                  << std::endl;
+        log_info("No info available for {} options.", solver);
     }
 #else
     OPENSIM_THROW(MocoTropterSolverNotAvailable);

--- a/Moco/Moco/MocoTropterSolver.cpp
+++ b/Moco/Moco/MocoTropterSolver.cpp
@@ -331,6 +331,8 @@ MocoSolution MocoTropterSolver::solveImpl() const {
     MocoTrajectory guess = getGuess();
     tropter::Iterate tropIterate = ocp->convertToTropterIterate(guess);
 
+    // Temporarily disable printing of negative muscle force warnings so the
+    // output stream isn't flooded while computing finite differences.
     Logger::Level origLoggerLevel = Logger::getLevel();
     Logger::setLevel(Logger::Level::Warn);
     tropter::Solution tropSolution;

--- a/Moco/Moco/MocoUtilities.h
+++ b/Moco/Moco/MocoUtilities.h
@@ -96,60 +96,6 @@ std::string getAbsolutePathnameFromXMLDocument(
         const std::string& documentFileName,
         const std::string& pathnameRelativeToDocument);
 
-/// @name Filling in a string with variables.
-/// @{
-
-#ifndef SWIG
-/// Return type for make_printable()
-/// @ingroup mocologutil
-template <typename T> struct make_printable_return { typedef T type; };
-/// Convert to types that can be printed with sprintf() (vsnprintf()).
-/// The generic template does not alter the type.
-/// @ingroup mocologutil
-template <typename T>
-inline typename make_printable_return<T>::type make_printable(const T& x) {
-    return x;
-}
-
-/// Specialization for std::string.
-/// @ingroup mocologutil
-template <> struct make_printable_return<std::string> {
-    typedef const char* type;
-};
-/// Specialization for std::string.
-/// @ingroup mocologutil
-template <>
-inline typename make_printable_return<std::string>::type make_printable(
-        const std::string& x) {
-    return x.c_str();
-}
-
-/// Format a char array using (C interface; mainly for internal use).
-/// @ingroup mocologutil
-OSIMMOCO_API std::string format_c(const char*, ...);
-
-/// Format a string in the style of sprintf. For example, the code
-/// `format("%s %d and %d yields %d", "adding", 2, 2, 4)` will produce
-/// "adding 2 and 2 yields 4".
-/// @ingroup mocologutil
-template <typename... Types>
-std::string format(const std::string& formatString, Types... args) {
-    return format_c(formatString.c_str(), make_printable(args)...);
-}
-
-/// Print a formatted string to std::cout. A newline is not included, but the
-/// stream is flushed.
-/// @ingroup mocologutil
-template <typename... Types>
-void printMessage(const std::string& formatString, Types... args) {
-    std::cout << format(formatString, args...);
-    std::cout.flush();
-}
-
-#endif // SWIG
-
-/// @}
-
 /// This class stores the formatting of a stream and restores that format
 /// when the StreamFormat is destructed.
 /// @ingroup mocologutil
@@ -231,18 +177,18 @@ TimeSeriesTable resample(const TimeSeriesTable& in, const TimeVector& newTime) {
     OPENSIM_THROW_IF(time.size() < 2, Exception,
             "Cannot resample if number of times is 0 or 1.");
     OPENSIM_THROW_IF(newTime[0] < time[0], Exception,
-            format("New initial time (%f) cannot be less than existing "
-                   "initial time (%f)",
+            fmt::format("New initial time ({}) cannot be less than existing "
+                   "initial time ({})",
                     newTime[0], time[0]));
     OPENSIM_THROW_IF(newTime[newTime.size() - 1] > time[time.size() - 1],
             Exception,
-            format("New final time (%f) cannot be greater than existing final "
-                   "time (%f)",
+            fmt::format("New final time ({}) cannot be greater than existing "
+                        "final time ({})",
                     newTime[newTime.size() - 1], time[time.size() - 1]));
     for (int itime = 1; itime < (int)newTime.size(); ++itime) {
         OPENSIM_THROW_IF(newTime[itime] < newTime[itime - 1], Exception,
-                format("New times must be non-decreasing, but "
-                       "time[%i] < time[%i] (%f < %f).",
+                fmt::format("New times must be non-decreasing, but "
+                       "time[{}] < time[{}] ({} < {}).",
                         itime, itime - 1, newTime[itime], newTime[itime - 1]));
     }
 
@@ -349,11 +295,8 @@ TimeSeriesTable_<T> analyze(Model model, const MocoTrajectory& trajectory,
                     if (dynamic_cast<const Output<T>*>(&output)) {
                         reporter->addToReport(output);
                     } else {
-                        std::cout << format("Warning: ignoring output %s of "
-                                            "type %s.",
-                                             output.getPathName(),
-                                             output.getTypeName())
-                                  << std::endl;
+                        log_warn("Ignoring output {} of type {}.",
+                                output.getPathName(), output.getTypeName());
                     }
                 }
             }
@@ -670,7 +613,7 @@ public:
     long long getElapsedTimeInNs() const {
         return SimTK::realTimeInNs() - m_startTime;
     }
-    /// This provides the elapsed time as a formatted string (using format()).
+    /// This provides the elapsed time as a formatted string (using formatNs()).
     std::string getElapsedTimeFormatted() const {
         return formatNs(getElapsedTimeInNs());
     }

--- a/Moco/Moco/MocoUtilities.h
+++ b/Moco/Moco/MocoUtilities.h
@@ -39,6 +39,7 @@
 #include <OpenSim/Common/GCVSplineSet.h>
 #include <OpenSim/Common/PiecewiseLinearFunction.h>
 #include <OpenSim/Common/Storage.h>
+#include <OpenSim/Common/Logger.h>
 
 namespace OpenSim {
 

--- a/Moco/Moco/MocoVariableInfo.cpp
+++ b/Moco/Moco/MocoVariableInfo.cpp
@@ -63,21 +63,18 @@ void MocoVariableInfo::validate() const {
                     n, fb.getUpper(), b.getUpper()));
 }
 
-void MocoVariableInfo::printDescription(std::ostream& stream) const {
+void MocoVariableInfo::printDescription() const {
     const auto bounds = getBounds();
-    stream << getName() << ". bounds: ";
-    bounds.printDescription(stream);
+    std::string str = fmt::format("  {}. bounds: {}", getName(), bounds);
     const auto initial = getInitialBounds();
     if (initial.isSet()) {
-        stream << " initial: ";
-        initial.printDescription(stream);
+        str += fmt::format(" initial: {}", initial);
     }
     const auto final = getFinalBounds();
     if (final.isSet()) {
-        stream << " final: ";
-        final.printDescription(stream);
+        str += fmt::format(" final: {}", final);
     }
-    stream << std::endl;
+    log_cout(str);
 }
 
 void MocoVariableInfo::constructProperties() {

--- a/Moco/Moco/MocoVariableInfo.cpp
+++ b/Moco/Moco/MocoVariableInfo.cpp
@@ -42,24 +42,24 @@ void MocoVariableInfo::validate() const {
     const auto fb = getFinalBounds();
 
     OPENSIM_THROW_IF(ib.isSet() && ib.getLower() < b.getLower(), Exception,
-            format("For variable %s, expected "
+            fmt::format("For variable {}, expected "
                    "[initial value lower bound] >= [lower bound], but "
-                   "intial value lower bound=%g, lower bound=%g.",
+                   "intial value lower bound={}, lower bound={}.",
                     n, ib.getLower(), b.getLower()));
     OPENSIM_THROW_IF(fb.isSet() && fb.getLower() < b.getLower(), Exception,
-            format("For variable %s, expected "
+            fmt::format("For variable {}, expected "
                    "[final value lower bound] >= [lower bound], but "
-                   "final value lower bound=%g, lower bound=%g.",
+                   "final value lower bound={}, lower bound={}.",
                     n, fb.getLower(), b.getLower()));
     OPENSIM_THROW_IF(ib.isSet() && ib.getUpper() > b.getUpper(), Exception,
-            format("For variable %s, expected "
+            fmt::format("For variable {}, expected "
                    "[initial value upper bound] >= [upper bound], but "
-                   "initial value upper bound=%g, upper bound=%g.",
+                   "initial value upper bound={}, upper bound={}.",
                     n, ib.getUpper(), b.getUpper()));
     OPENSIM_THROW_IF(fb.isSet() && fb.getUpper() > b.getUpper(), Exception,
-            format("For variable %s, expected "
+            fmt::format("For variable {}, expected "
                    "[final value upper bound] >= [upper bound], but "
-                   "final value upper bound=%g, upper bound=%g.",
+                   "final value upper bound={}, upper bound={}.",
                     n, fb.getUpper(), b.getUpper()));
 }
 

--- a/Moco/Moco/MocoVariableInfo.h
+++ b/Moco/Moco/MocoVariableInfo.h
@@ -63,7 +63,7 @@ public:
     void validate() const;
 
     /// Print the bounds on this variable.
-    void printDescription(std::ostream& stream = std::cout) const;
+    void printDescription() const;
 
 protected:
     OpenSim_DECLARE_LIST_PROPERTY_ATMOST(bounds, double, 2,

--- a/Moco/Moco/ModelOperators.h
+++ b/Moco/Moco/ModelOperators.h
@@ -83,8 +83,10 @@ public:
     ModOpTendonComplianceDynamicsModeDGF(std::string mode) : 
             ModOpTendonComplianceDynamicsModeDGF() {
         OPENSIM_THROW_IF(mode != "explicit" && mode != "implicit", Exception,
-            format("The tendon compliance dynamics mode must be either "
-                "'explicit' or 'implicit', but %s was provided.", mode));
+                fmt::format("The tendon compliance dynamics mode must be "
+                            "either 'explicit' or 'implicit', but {} was "
+                            "provided.",
+                        mode));
         set_mode(std::move(mode));
     }
     void operate(Model& model, const std::string&) const override {

--- a/Moco/Moco/tropter/TropterProblem.h
+++ b/Moco/Moco/tropter/TropterProblem.h
@@ -86,7 +86,7 @@ protected:
 
         std::string formattedTimeString(getMocoFormattedDateTime(true));
         m_fileDeletionThrower = OpenSim::make_unique<FileDeletionThrower>(
-                format("delete_this_to_stop_optimization_%s_%s.txt",
+                fmt::format("delete_this_to_stop_optimization_{}_{}.txt",
                         m_mocoProbRep.getName(), formattedTimeString));
     }
 
@@ -168,22 +168,18 @@ protected:
             // constraint derivatives? For now, disallow enforcing derivatives
             // if non-holonomic or acceleration constraints present.
             OPENSIM_THROW_IF(enforceConstraintDerivs && mv != 0, Exception,
-                    format("Enforcing constraint derivatives is supported only "
-                           "for "
-                           "holonomic (position-level) constraints. "
-                           "There are %i velocity-level "
-                           "scalar constraints associated with the model "
-                           "Constraint "
-                           "at ConstraintIndex %i.",
+                    fmt::format("Enforcing constraint derivatives is supported "
+                                "only for holonomic (position-level) "
+                                "constraints. There are {} velocity-level "
+                                "scalar constraints associated with the model "
+                                "Constraint at ConstraintIndex {}.",
                             mv, cid));
             OPENSIM_THROW_IF(enforceConstraintDerivs && ma != 0, Exception,
-                    format("Enforcing constraint derivatives is supported only "
-                           "for "
-                           "holonomic (position-level) constraints. "
-                           "There are %i acceleration-level "
-                           "scalar constraints associated with the model "
-                           "Constraint "
-                           "at ConstraintIndex %i.",
+                    fmt::format("Enforcing constraint derivatives is supported "
+                                "only for holonomic (position-level) "
+                                "constraints. There are {} acceleration-level "
+                                "scalar constraints associated with the model "
+                                "Constraint at ConstraintIndex {}.",
                             ma, cid));
 
             m_total_mp += mp;
@@ -227,10 +223,9 @@ protected:
                         OPENSIM_THROW_IF(
                                 multInfo.getName().substr(0, 6) != "lambda",
                                 Exception,
-                                format("Expected the multiplier name for this "
-                                       "constraint to begin with 'lambda' but "
-                                       "it "
-                                       "begins with '%s'.",
+                                fmt::format("Expected the multiplier name for "
+                                            "this constraint to begin with "
+                                            "'lambda' but it begins with '{}'.",
                                         multInfo.getName().substr(0, 6)));
                         this->add_diffuse(std::string(multInfo.getName())
                                                   .replace(0, 6, "gamma"),

--- a/Moco/Sandbox/sandboxMarkerTrackingContactWholeBody/sandboxCalibrateContact.cpp
+++ b/Moco/Sandbox/sandboxMarkerTrackingContactWholeBody/sandboxCalibrateContact.cpp
@@ -17,7 +17,6 @@
  * -------------------------------------------------------------------------- */
 
 
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Common/osimCommon.h>
 #include <OpenSim/Simulation/osimSimulation.h>
 #include <OpenSim/Actuators/osimActuators.h>
@@ -754,9 +753,6 @@ void toyCMAES() {
 }
 
 int main() {
-
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     // calibrateBall();
 

--- a/Moco/Sandbox/sandboxMocoTrack/sandboxMocoTrack.cpp
+++ b/Moco/Sandbox/sandboxMocoTrack/sandboxMocoTrack.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <Moco/osimMoco.h>
-#include <OpenSim/Common/LogManager.h>
 
 #include <OpenSim/OpenSim.h>
 
@@ -301,9 +300,6 @@ Model createModel(bool removeMuscles = false, bool addAnkleExo = false) {
 
 void smoothSolutionControls(Model model, std::string statesFile, 
         const std::string& guessFile) {
-
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     MocoTrack track;
     track.setName("smoothed");
@@ -796,9 +792,6 @@ MocoSolution runExoskeletonProblem(const std::string& trackedIterateFile,
 }
 
 int main() {
-
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     // Baseline tracking problem w/o muscles.
     // --------------------------------------

--- a/Moco/Sandbox/sandboxMuscle.cpp
+++ b/Moco/Sandbox/sandboxMuscle.cpp
@@ -24,7 +24,6 @@
 
 #include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 #include <OpenSim/Common/GCVSpline.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 
@@ -463,8 +462,6 @@ void testHangingMuscleMinimumTime(
 
 int main() {
 
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     testDeGrooteFregly2016Muscle();
 
     testHangingMuscleMinimumTime<MocoCasADiSolver>(true, true);

--- a/Moco/Tests/testConstraints.cpp
+++ b/Moco/Tests/testConstraints.cpp
@@ -29,7 +29,6 @@ using Catch::Contains;
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/GCVSpline.h>
 #include <OpenSim/Common/LinearFunction.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Common/Sine.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
 #include <OpenSim/Simulation/osimSimulation.h>
@@ -620,8 +619,6 @@ void testDoublePendulumPointOnLine(
 template <typename SolverType>
 void testDoublePendulumCoordinateCoupler(MocoSolution& solution,
         bool enforce_constraint_derivatives, std::string dynamics_mode) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     MocoStudy study;
     study.setName("double_pendulum_coordinate_coupler");
 
@@ -933,8 +930,6 @@ protected:
 /// actuators must produce an equal control trajectory.
 TEMPLATE_TEST_CASE(
         "DoublePendulumEqualControl", "", MocoTropterSolver, MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     OpenSim::Object::registerType(EqualControlConstraint());
     MocoStudy study;
     study.setName("double_pendulum_equal_control");
@@ -1002,8 +997,6 @@ TEMPLATE_TEST_CASE(
 TEMPLATE_TEST_CASE(
         "Parameters are set properly for Base and DisabledConstraints", "",
         MocoTropterSolver /*, too damn slow: MocoCasADiSolver*/) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     Model model;
     auto* body = new Body("b", 0.7, SimTK::Vec3(0), SimTK::Inertia(1));
     model.addBody(body);
@@ -1163,8 +1156,6 @@ private:
 // accelerations. This test ensures that these accelerations and multipliers are
 // those that Moco specified, not what Simbody computes.
 TEST_CASE("Goals use Moco-defined accelerations and multipliers") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     MocoStudy study;
     study.setName("mass_welded");
     MocoProblem& problem = study.updProblem();
@@ -1320,8 +1311,6 @@ TEST_CASE("Goals use Moco-defined accelerations and multipliers") {
 
 
 TEST_CASE("Multipliers are correct", "") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     SECTION("Body welded to ground") {
         auto dynamics_mode =
                 GENERATE(as<std::string>{}, "implicit", "explicit");
@@ -1426,8 +1415,6 @@ TEST_CASE("Multipliers are correct", "") {
 // (PositionMotion) and kinematic constraints. This test is similar to the one
 // above except that we prescribe motions for tx and ty.
 TEST_CASE("Prescribed kinematics with kinematic constraints", "") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     Model model = ModelFactory::createPlanarPointMass();
     model.set_gravity(Vec3(0));
     CoordinateCouplerConstraint* constraint = new CoordinateCouplerConstraint();

--- a/Moco/Tests/testContact.cpp
+++ b/Moco/Tests/testContact.cpp
@@ -23,7 +23,6 @@
 #include "Testing.h"
 #include <Moco/osimMoco.h>
 
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 
 const double FRICTION_COEFFICIENT = 0.7;
@@ -414,8 +413,6 @@ SimTK::Real testSmoothSphereHalfSpaceForce_NormalForce()
 // of the mass (from testSmoothSphereHalfSpaceForce_NormalForce()).
 void testSmoothSphereHalfSpaceForce_FrictionForce(
     const SimTK::Real& equilibriumHeight) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     Model model(createBallHalfSpaceModel());
 
@@ -547,8 +544,6 @@ TEST_CASE("testSmoothSphereHalfSpaceForce") {
 
 
 TEST_CASE("MocoContactTrackingGoal") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     // We drop a ball from a prescribed initial height, record the contact
     // force, then solve a trajectory optimization that tracks the recorded

--- a/Moco/Tests/testImplicit.cpp
+++ b/Moco/Tests/testImplicit.cpp
@@ -21,7 +21,6 @@
 #include <Moco/osimMoco.h>
 
 #include <OpenSim/Actuators/CoordinateActuator.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 
@@ -114,8 +113,6 @@ MocoSolution solveDoublePendulumSwingup(const std::string& dynamics_mode) {
 
 TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
         "[implicit]", MocoTropterSolver, MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     GIVEN("solutions to implicit and explicit problems") {
 
         auto solutionImplicit =
@@ -170,8 +167,6 @@ TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
 
 TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
         "[implicit]", MocoTropterSolver, MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     class MyPathConstraint : public MocoPathConstraint {
         OpenSim_DECLARE_CONCRETE_OBJECT(MyPathConstraint, MocoPathConstraint);
         void initializeOnModelImpl(
@@ -210,8 +205,6 @@ TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
 
 TEMPLATE_TEST_CASE("Combining implicit dynamics with kinematic constraints",
         "[implicit]", /*MocoTropterSolver,*/ MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
     GIVEN("MocoProblem with a kinematic constraint") {
         MocoStudy study;
         auto& prob = study.updProblem();

--- a/Moco/Tests/testMocoActuators.cpp
+++ b/Moco/Tests/testMocoActuators.cpp
@@ -23,7 +23,6 @@
 
 #include <OpenSim/Actuators/ActivationCoordinateActuator.h>
 #include <OpenSim/Common/GCVSpline.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 
@@ -1093,9 +1092,6 @@ TEMPLATE_TEST_CASE("Hanging muscle minimum time", "", MocoCasADiSolver) {
 
     // TODO: Some problem has a bad initial guess and the constraint violation
     // goes to 1e+14. Maybe the bounds on the coordinate should be tighter.
-
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     CAPTURE(ignoreActivationDynamics);
     CAPTURE(ignoreTendonCompliance);

--- a/Moco/Tests/testMocoAnalytic.cpp
+++ b/Moco/Tests/testMocoAnalytic.cpp
@@ -22,7 +22,6 @@
 
 #include <OpenSim/Actuators/SpringGeneralizedForce.h>
 #include <OpenSim/Actuators/CoordinateActuator.h>
-#include <OpenSim/Common/LogManager.h>
 
 using namespace OpenSim;
 
@@ -103,8 +102,6 @@ TEMPLATE_TEST_CASE("Second order linear min effort", "", MocoTropterSolver,
 /// and Control. New York‐London‐Sydney‐Toronto. John Wiley & Sons. 1975.
 TEMPLATE_TEST_CASE("Linear tangent steering", "", /*MocoTropterSolver, TODO*/
         MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
     // The problem is parameterized by a, T, and h, with 0 < 4h/(aT^2) < 1.
     const double a = 5;
     const double finalTime = 1; // "T"

--- a/Moco/Tests/testMocoGoals.cpp
+++ b/Moco/Tests/testMocoGoals.cpp
@@ -22,7 +22,6 @@
 
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/PointActuator.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 
@@ -192,8 +191,6 @@ TEMPLATE_TEST_CASE(
 }
 
 TEST_CASE("Enabled Goals", "") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
     double x = 23920;
     MocoFinalTimeGoal cost;
     Model model;
@@ -259,8 +256,6 @@ void testDoublePendulumTracking(MocoStudy study,
 
 TEMPLATE_TEST_CASE("Test tracking goals", "", MocoTropterSolver,
         MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     // Start with double pendulum problem to minimize control effort to create
     // a controls trajectory to track.
@@ -499,8 +494,6 @@ public:
 
 TEMPLATE_TEST_CASE("Endpoint constraints", "", MocoCasADiSolver) {
     // TODO test with Tropter.
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     MocoStudy study;
     auto& problem = study.updProblem();
@@ -554,8 +547,6 @@ TEMPLATE_TEST_CASE("Endpoint constraints", "", MocoCasADiSolver) {
 }
 
 TEMPLATE_TEST_CASE("MocoPeriodicityGoal", "", MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     MocoStudy study;
     auto& problem = study.updProblem();

--- a/Moco/Tests/testMocoInterface.cpp
+++ b/Moco/Tests/testMocoInterface.cpp
@@ -23,7 +23,6 @@
 
 #include <OpenSim/Actuators/BodyActuator.h>
 #include <OpenSim/Actuators/CoordinateActuator.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Common/STOFileAdapter.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
@@ -87,8 +86,6 @@ TEMPLATE_TEST_CASE(
         "Non-uniform mesh", "", MocoTropterSolver, MocoCasADiSolver) {
     auto transcriptionScheme =
             GENERATE(as<std::string>{}, "trapezoidal", "hermite-simpson");
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
     MocoStudy study;
     double finalTime = 5.0;
     study.setName("sliding_mass");
@@ -786,8 +783,6 @@ TEMPLATE_TEST_CASE("Set infos with regular expression", "", MocoCasADiSolver,
 }
 TEMPLATE_TEST_CASE(
         "Disable Actuators", "", MocoCasADiSolver, MocoTropterSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     MocoSolution solution;
     MocoSolution solution2;
@@ -930,8 +925,6 @@ TEMPLATE_TEST_CASE("State tracking", "", MocoTropterSolver, MocoCasADiSolver) {
 }
 
 TEMPLATE_TEST_CASE("Guess", "", MocoTropterSolver, MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
@@ -1546,8 +1539,6 @@ TEST_CASE("MocoTrajectory") {
 }
 
 TEST_CASE("MocoTrajectory isCompatible") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
     MocoProblem problem;
     problem.setModel(createSlidingMassModel());
     problem.setTimeBounds(MocoInitialBounds(0), MocoFinalBounds(0, 10));
@@ -1708,8 +1699,6 @@ TEST_CASE("Interpolate", "") {
 }
 
 TEMPLATE_TEST_CASE("Sliding mass", "", MocoTropterSolver, MocoCasADiSolver) {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     MocoSolution solution = study.solve();
     int numTimes = 20;
@@ -1852,8 +1841,6 @@ void testSkippingOverQuaternionSlots(
 }
 
 TEST_CASE("Skip over empty quaternion slots", "") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cout.rdbuf(LogManager::cout.rdbuf());
 
     testSkippingOverQuaternionSlots<MocoTropterSolver>(
             false, false, "explicit");

--- a/Moco/Tests/testMocoInverse.cpp
+++ b/Moco/Tests/testMocoInverse.cpp
@@ -18,8 +18,6 @@
 
 #include <Moco/osimMoco.h>
 
-#include <OpenSim/Common/LogManager.h>
-
 #define CATCH_CONFIG_MAIN
 #include "Testing.h"
 
@@ -118,8 +116,6 @@ TEST_CASE("PrescribedKinematics direct collocation auxiliary dynamics") {
 }
 
 TEST_CASE("MocoInverse Rajagopal2016, 18 muscles") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     MocoInverse inverse;
     ModelProcessor modelProcessor =

--- a/Moco/Tests/testMocoTrack.cpp
+++ b/Moco/Tests/testMocoTrack.cpp
@@ -18,8 +18,6 @@
 
 #include <Moco/osimMoco.h>
 
-#include <OpenSim/Common/LogManager.h>
-
 #define CATCH_CONFIG_MAIN
 #include "Testing.h"
 
@@ -46,8 +44,6 @@ TEST_CASE("MocoTrack interface") {
 }
 
 TEST_CASE("MocoTrack gait10dof18musc") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     MocoTrack track;
 

--- a/Moco/Tests/testModelProcessor.cpp
+++ b/Moco/Tests/testModelProcessor.cpp
@@ -23,14 +23,11 @@
 
 #include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 #include <OpenSim/Analyses/MuscleAnalysis.h>
-#include <OpenSim/Common/LogManager.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 
 using namespace OpenSim;
 
 TEST_CASE("ModelProcessor") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     class MyModelOperator : public ModelOperator {
         OpenSim_DECLARE_CONCRETE_OBJECT(MyModelOperator, ModelOperator);

--- a/Moco/Tests/testTableProcessor.cpp
+++ b/Moco/Tests/testTableProcessor.cpp
@@ -20,13 +20,9 @@
 #include "Testing.h"
 #include <Moco/Common/TableProcessor.h>
 
-#include <OpenSim/Common/LogManager.h>
-
 using namespace OpenSim;
 
 TEST_CASE("TableProcessor") {
-    std::cout.rdbuf(LogManager::cout.rdbuf());
-    std::cerr.rdbuf(LogManager::cerr.rdbuf());
 
     class MyTableOperator : public TableOperator {
         OpenSim_DECLARE_CONCRETE_OBJECT(MyTableOperator, TableOperator);

--- a/dependencies/opensim-core.cmake
+++ b/dependencies/opensim-core.cmake
@@ -4,7 +4,7 @@
 # will invalidate its cached opensim-core installation if we change the commit.
 # This commented commit hash is not actually used in the superbuild.
 # opensim-core commit:
-# 840bfac5d28a70a16335f441950bf669407031e2
+# 82ec3d1c74af1ff1893d9c5453ef6c52fe2e2fc9
 
 AddDependency(NAME       opensim-core
               URL        ${CMAKE_SOURCE_DIR}/../opensim-core

--- a/dependencies/opensim-core.cmake
+++ b/dependencies/opensim-core.cmake
@@ -4,7 +4,7 @@
 # will invalidate its cached opensim-core installation if we change the commit.
 # This commented commit hash is not actually used in the superbuild.
 # opensim-core commit:
-# 2f5d4b09722e57359e2ff1787328527050a4d34e
+# 840bfac5d28a70a16335f441950bf669407031e2
 
 AddDependency(NAME       opensim-core
               URL        ${CMAKE_SOURCE_DIR}/../opensim-core
@@ -38,7 +38,16 @@ if(SUPERBUILD_opensim-core)
                   GIT_TAG    3dd23e3280f213bacefdf5fcb04857bf52e90917
                   CMAKE_ARGS -DCMAKE_DEBUG_POSTFIX:STRING=_d)
 
-    add_dependencies(opensim-core BTK simbody docopt)
+    AddDependency(NAME       spdlog
+                  DEFAULT    ON
+                  GIT_URL    https://github.com/gabime/spdlog.git
+                  GIT_TAG    v1.4.1
+                  CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
+                             -DSPDLOG_BUILD_TESTS:BOOL=OFF
+                             -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF
+                             -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
+
+    add_dependencies(opensim-core BTK simbody docopt spdlog)
 endif()
 
 


### PR DESCRIPTION
Fixes issue #642 

### Brief summary of changes

- Use `spdlog` instead of `std::cout`
- Use `fmt::format()` instead of `OpenSim::format()`.
- Remove `OpenSim::format()`

### Details

I opened an `opensim-core` PR to add new constructors for `Exception` (https://github.com/opensim-org/opensim-core/pull/2795); I may make another sweep through these changes to take advantage of that PR.

### CHANGELOG.md (choose one)

- [x] updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/643)
<!-- Reviewable:end -->
