### PR TITLE
Ensure model is not null before converting degrees to radians.

### DIFF
--- a/Moco/Moco/Common/TableProcessor.h
+++ b/Moco/Moco/Common/TableProcessor.h
@@ -72,7 +72,7 @@ public:
         set_filepath(std::move(filepath));
     }
     /// Process and obtain the table. If a filepath is provided, it will be
-    /// evaluated relative `relativeToDirectory`.
+    /// evaluated relative to `relativeToDirectory`.
     /// If a model is provided, it is used to convert columns from degrees to
     /// radians (if the table has a header with inDegrees=yes) before any
     /// operations are performed. This model is accessible by any
@@ -100,8 +100,10 @@ public:
             table = TimeSeriesTable(path);
         }
 
-        if (table.hasTableMetaDataKey("inDegrees") &&
+        if (model && table.hasTableMetaDataKey("inDegrees") &&
                 table.getTableMetaDataAsString("inDegrees") == "yes") {
+            OPENSIM_THROW_IF(
+                    !model->hasSystem(), ModelHasNoSystem, model->getName());
             model->getSimbodyEngine().convertDegreesToRadians(table);
         }
 

--- a/Moco/Moco/MocoTrack.cpp
+++ b/Moco/Moco/MocoTrack.cpp
@@ -225,7 +225,7 @@ TimeSeriesTable MocoTrack::configureStateTracking(
             states.getIndependentColumn().back(), m_timeInfo);
 
     // Write tracked states to file in case any label updates or filtering
-    // occured.
+    // occurred.
     writeTableToFile(states, getName() + "_tracked_states.sto");
 
     // Return tracked states to possibly include in the guess.


### PR DESCRIPTION
Related to #616 

### Brief summary of changes

In `TableProcessor::process()`, add a missing check to see if the `model` pointer is null before using the pointer.

### Details (optional)

I know we've discussed moving the degrees-to-radians conversion to its own `TableOperator`, but that could require updates throughout the tests/examples. I wanted to just fix this blatant bug for now.

### CHANGELOG.md (choose one)

- [x] no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/644)
<!-- Reviewable:end -->
