### PR TITLE
Remove fmt::format() with exception macros.

### DIFF
--- a/Moco/Examples/C++/exampleCustomImplicitAuxiliaryDynamics/exampleCustomImplicitAuxiliaryDynamics.cpp
+++ b/Moco/Examples/C++/exampleCustomImplicitAuxiliaryDynamics/exampleCustomImplicitAuxiliaryDynamics.cpp
@@ -97,9 +97,9 @@ private:
         OPENSIM_THROW_IF_FRMOBJ(get_foo_dynamics_mode() != "implicit" &&
                                         get_foo_dynamics_mode() != "explicit",
                 Exception,
-                fmt::format("Expected foo_dynamics_mode to be 'implicit' or "
-                            "'explicit', but got '{}'.",
-                        get_foo_dynamics_mode()));
+                "Expected foo_dynamics_mode to be 'implicit' or "
+                "'explicit', but got '{}'.",
+                get_foo_dynamics_mode());
         m_foo_dynamics_mode_implicit = get_foo_dynamics_mode() == "implicit";
     }
     void extendInitStateFromProperties(SimTK::State& s) const override {

--- a/Moco/Executable/opensim-moco.cpp
+++ b/Moco/Executable/opensim-moco.cpp
@@ -58,8 +58,7 @@ void run_tool(std::string setupFile, bool visualize) {
     auto obj = std::unique_ptr<Object>(Object::makeObjectFromFile(setupFile));
 
     OPENSIM_THROW_IF(obj == nullptr, Exception,
-            fmt::format("A problem occurred when trying to load file '{}'.",
-                    setupFile));
+            "A problem occurred when trying to load file '{}'.", setupFile);
 
     if (const auto* moco = dynamic_cast<const MocoStudy*>(obj.get())) {
         auto solution = moco->solve();

--- a/Moco/Moco/Common/TableProcessor.h
+++ b/Moco/Moco/Common/TableProcessor.h
@@ -163,9 +163,8 @@ public:
             const override {
         if (get_cutoff_frequency() != -1) {
             OPENSIM_THROW_IF(get_cutoff_frequency() <= 0, Exception,
-                    fmt::format("Expected cutoff frequency to be positive, "
-                                "but got {}.",
-                            get_cutoff_frequency()));
+                    "Expected cutoff frequency to be positive, but got {}.",
+                    get_cutoff_frequency());
 
             table = filterLowpass(table, get_cutoff_frequency(), true);
         }

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
@@ -982,10 +982,9 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
 
         } else {
             OPENSIM_THROW_IF(!allowUnsupportedMuscles, Exception,
-                    fmt::format("Muscle '{}' of type {} is unsupported and "
-                                "allowUnsupportedMuscles=false.",
-                            muscBase.getName(),
-                            muscBase.getConcreteClassName()));
+                    "Muscle '{}' of type {} is unsupported and "
+                    "allowUnsupportedMuscles=false.",
+                    muscBase.getName(), muscBase.getConcreteClassName());
             continue;
         }
 
@@ -1043,13 +1042,11 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
     for (const auto* musc : musclesToDelete) {
         int index = model.getForceSet().getIndex(musc, 0);
         OPENSIM_THROW_IF(index == -1, Exception,
-                fmt::format("Muscle with name {} not found in ForceSet.",
-                        musc->getName()));
+                "Muscle with name {} not found in ForceSet.", musc->getName());
         bool success = model.updForceSet().remove(index);
         OPENSIM_THROW_IF(!success, Exception,
-                fmt::format("Attempt to remove muscle with "
-                            "name {} was unsuccessful.",
-                        musc->getName()));
+                "Attempt to remove muscle with name {} was unsuccessful.",
+                musc->getName());
     }
 
     model.finalizeFromProperties();

--- a/Moco/Moco/Components/ModelFactory.cpp
+++ b/Moco/Moco/Components/ModelFactory.cpp
@@ -195,13 +195,11 @@ void ModelFactory::replaceMusclesWithPathActuators(OpenSim::Model &model) {
     for (const auto* musc : musclesToDelete) {
         int index = model.getForceSet().getIndex(musc, 0);
         OPENSIM_THROW_IF(index == -1, Exception,
-                fmt::format("Muscle with name {} not found in ForceSet.",
-                        musc->getName()));
+                "Muscle with name {} not found in ForceSet.", musc->getName());
         bool success = model.updForceSet().remove(index);
         OPENSIM_THROW_IF(!success, Exception,
-                fmt::format("Attempt to remove muscle with "
-                            "name {} was unsuccessful.",
-                        musc->getName()));
+                "Attempt to remove muscle with name {} was unsuccessful.",
+                musc->getName());
     }
 }
 
@@ -259,8 +257,7 @@ void ModelFactory::removeMuscles(Model& model) {
     for (const auto* musc : musclesToDelete) {
         int index = model.getForceSet().getIndex(musc, 0);
         OPENSIM_THROW_IF(index == -1, Exception,
-                fmt::format("Muscle with name {} not found in ForceSet.",
-                        musc->getName()));
+                "Muscle with name {} not found in ForceSet.", musc->getName());
         model.updForceSet().remove(index);
     }
 }
@@ -269,9 +266,9 @@ void ModelFactory::createReserveActuators(Model& model, double optimalForce,
         double bound,
         bool skipCoordinatesWithExistingActuators) {
     OPENSIM_THROW_IF(optimalForce <= 0, Exception,
-            fmt::format("Invalid value ({}) for create_reserve_actuators; "
-                   "should be -1 or positive.",
-                    optimalForce));
+            "Invalid value ({}) for create_reserve_actuators; should be -1 or "
+            "positive.",
+            optimalForce);
 
     log_info("Adding reserve actuators with an optimal force of {}...",
             optimalForce);
@@ -306,8 +303,7 @@ void ModelFactory::createReserveActuators(Model& model, double optimalForce,
             actu->setOptimalForce(optimalForce);
             if (!SimTK::isNaN(bound)) {
                 OPENSIM_THROW_IF(bound < 0, Exception,
-                        fmt::format("Expected a non-negative bound but got {}.",
-                                bound));
+                        "Expected a non-negative bound but got {}.", bound);
                 actu->setMinControl(-bound);
                 actu->setMaxControl(bound);
             }

--- a/Moco/Moco/Components/MultivariatePolynomialFunction.h
+++ b/Moco/Moco/Components/MultivariatePolynomialFunction.h
@@ -62,8 +62,8 @@ public:
     SimTKMultivariatePolynomial(const SimTK::Vector_<T>& coefficients,
             const int& dimension, const int& order) :
             coefficients(coefficients), dimension(dimension), order(order) {
-        OPENSIM_THROW_IF(dimension < 0 || dimension > 4, Exception, fmt::format(
-                "Expected dimension >= 0 && <=4 but got {}.", dimension));
+        OPENSIM_THROW_IF(dimension < 0 || dimension > 4, Exception,
+                "Expected dimension >= 0 && <=4 but got {}.", dimension);
         std::array<int, 4> nq {{0, 0, 0, 0}};
         int coeff_nr = 0;
         for (nq[0] = 0; nq[0] < order + 1; ++nq[0]) {
@@ -85,8 +85,8 @@ public:
             }
         }
         OPENSIM_THROW_IF(coefficients.size() != coeff_nr, Exception,
-                fmt::format("Expected {} coefficients but got {}.", coeff_nr,
-                        coefficients.size()));
+                "Expected {} coefficients but got {}.", coeff_nr,
+                coefficients.size());
     }
     T calcValue(const SimTK::Vector& x) const override {
         std::array<int, 4> nq {{0, 0, 0, 0}};

--- a/Moco/Moco/Components/PositionMotion.cpp
+++ b/Moco/Moco/Components/PositionMotion.cpp
@@ -136,8 +136,7 @@ std::unique_ptr<PositionMotion> PositionMotion::createFromTable(
         } else {
             OPENSIM_THROW_IF(!model.findComponent<Component>(coordPath) &&
                                      !allowExtraColumns,
-                    Exception,
-                    fmt::format("Column '{}' is not a coordinate.", label));
+                    Exception, "Column '{}' is not a coordinate.", label);
         }
     }
     return posmot;
@@ -193,7 +192,7 @@ void PositionMotion::extendRealizeTopology(SimTK::State& state) const {
     for (const auto& coord : coords) {
         const auto& path = coord.getAbsolutePathString();
         OPENSIM_THROW_IF(!get_functions().contains(path), Exception,
-                fmt::format("No function provided for coordinate '{}'.", path));
+                "No function provided for coordinate '{}'.", path);
     }
 
     // Create a mapping from SimTK position DOFs to OpenSim Coordinates.

--- a/Moco/Moco/MocoBounds.cpp
+++ b/Moco/Moco/MocoBounds.cpp
@@ -36,8 +36,8 @@ MocoBounds::MocoBounds(double lower, double upper) : MocoBounds() {
     OPENSIM_THROW_IF(SimTK::isNaN(lower) || SimTK::isNaN(upper), Exception, 
         "NaN value detected. Please provide a non-NaN values for the bounds.");
     OPENSIM_THROW_IF(lower > upper, Exception,
-        fmt::format("Expected lower <= upper, but lower={} and upper={}.",
-                lower, upper));
+            "Expected lower <= upper, but lower={} and upper={}.", lower,
+            upper);
     append_bounds(lower);
     append_bounds(upper);
 }

--- a/Moco/Moco/MocoCasADiSolver/CasOCSolver.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCSolver.cpp
@@ -32,9 +32,8 @@ std::unique_ptr<Transcription> Solver::createTranscription() const {
     } else if (m_transcriptionScheme == "hermite-simpson") {
         transcription = OpenSim::make_unique<HermiteSimpson>(*this, m_problem);
     } else {
-        OPENSIM_THROW(
-                Exception, fmt::format("Unknown transcription scheme '{}'.",
-                                   m_transcriptionScheme));
+        OPENSIM_THROW(Exception, "Unknown transcription scheme '{}'.",
+                m_transcriptionScheme);
     }
     return transcription;
 }
@@ -64,7 +63,7 @@ void Solver::setSparsityDetectionRandomCount(int count) {
 void Solver::setParallelism(std::string parallelism, int numThreads) {
     m_parallelism = parallelism;
     OPENSIM_THROW_IF(numThreads < 1, OpenSim::Exception,
-            fmt::format("Expected numThreads >= 1 but got {}.", numThreads));
+            "Expected numThreads >= 1 but got {}.", numThreads);
     m_numThreads = numThreads;
 }
 

--- a/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/Moco/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -622,9 +622,9 @@ Solution Transcription::solve(const Iterate& guessOrig) {
         // were removed.
         OPENSIM_THROW_IF(slacks.size2() != m_numMeshInteriorPoints,
                 OpenSim::Exception,
-                fmt::format("Expected slack variables to be length {}, "
-                            "but they are length {}.",
-                        m_numMeshInteriorPoints, slacks.size2()));
+                "Expected slack variables to be length {}, but they are length "
+                "{}.",
+                m_numMeshInteriorPoints, slacks.size2());
     }
 
     // Create the CasADi NLP function.

--- a/Moco/Moco/MocoCasADiSolver/CasOCTranscription.h
+++ b/Moco/Moco/MocoCasADiSolver/CasOCTranscription.h
@@ -49,11 +49,9 @@ public:
         const auto shape = meshIndices.size();
         OPENSIM_THROW_IF(shape.first != 1 || shape.second != m_numGridPoints,
                 OpenSim::Exception,
-                fmt::format(
-                        "createMeshIndicesImpl() must return a "
-                        "row vector of shape length [1, {}], but a matrix of "
-                        "shape [{}, {}] was returned.",
-                        m_numGridPoints, shape.first, shape.second));
+                "createMeshIndicesImpl() must return a row vector of shape "
+                "length [1, {}], but a matrix of shape [{}, {}] was returned.",
+                m_numGridPoints, shape.first, shape.second);
         OPENSIM_THROW_IF(!SimTK::isNumericallyEqual(
                                  casadi::DM::sum2(meshIndices).scalar(),
                                  m_numMeshPoints),

--- a/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -179,11 +179,11 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
         OPENSIM_THROW_IF(get_transcription_scheme() != "hermite-simpson" &&
                                  get_enforce_constraint_derivatives(),
                 Exception,
-                fmt::format("If enforcing derivatives of model kinematic "
-                       "constraints, then the property 'transcription_scheme' "
-                       "must be set to 'hermite-simpson'. "
-                       "Currently, it is set to '{}'.",
-                        get_transcription_scheme()));
+                "If enforcing derivatives of model kinematic "
+                "constraints, then the property 'transcription_scheme' "
+                "must be set to 'hermite-simpson'. "
+                "Currently, it is set to '{}'.",
+                get_transcription_scheme());
     }
 
     checkPropertyInRangeOrSet(*this, getProperty_num_mesh_intervals(), 0,
@@ -280,10 +280,10 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
     casSolver->setMinimizeImplicitMultibodyAccelerations(
             get_minimize_implicit_multibody_accelerations());
     OPENSIM_THROW_IF(get_implicit_multibody_accelerations_weight() < 0,
-            Exception, fmt::format(
-                "Property implicit_multibody_accelerations_weight must be "
-                "non-negative, but it is set to {}.",
-                get_implicit_multibody_accelerations_weight()));
+            Exception,
+            "Property implicit_multibody_accelerations_weight must be "
+            "non-negative, but it is set to {}.",
+            get_implicit_multibody_accelerations_weight());
     casSolver->setImplicitMultibodyAccelerationsWeight(
             get_implicit_multibody_accelerations_weight());
 
@@ -291,11 +291,10 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
             convertBounds(get_implicit_auxiliary_derivative_bounds()));
     casSolver->setMinimizeImplicitAuxiliaryDerivatives(
             get_minimize_implicit_auxiliary_derivatives());
-    OPENSIM_THROW_IF(get_implicit_auxiliary_derivatives_weight() < 0,
-            Exception, fmt::format(
-                    "Property implicit_auxiliary_derivatives_weight must be "
-                    "non-negative, but it is set to {}.",
-                    get_implicit_auxiliary_derivatives_weight()));
+    OPENSIM_THROW_IF(get_implicit_auxiliary_derivatives_weight() < 0, Exception,
+            "Property implicit_auxiliary_derivatives_weight must be "
+            "non-negative, but it is set to {}.",
+            get_implicit_auxiliary_derivatives_weight());
     casSolver->setImplicitAuxiliaryDerivativesWeight(
             get_implicit_auxiliary_derivatives_weight());
 

--- a/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
@@ -128,19 +128,17 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
             // constraint derivatives? For now, disallow enforcing derivatives
             // if non-holonomic or acceleration constraints present.
             OPENSIM_THROW_IF(enforceConstraintDerivs && mv != 0, Exception,
-                    fmt::format("Enforcing constraint derivatives is supported "
-                                "only for holonomic (position-level) "
-                                "constraints. There are {} velocity-level "
-                                "scalar constraints associated with the model "
-                                "Constraint at ConstraintIndex {}.",
-                            mv, cid));
+                    "Enforcing constraint derivatives is supported only for "
+                    "holonomic (position-level) constraints. There are {} "
+                    "velocity-level scalar constraints associated with the "
+                    "model Constraint at ConstraintIndex {}.",
+                    mv, cid);
             OPENSIM_THROW_IF(enforceConstraintDerivs && ma != 0, Exception,
-                    fmt::format("Enforcing constraint derivatives is supported "
-                                "only for holonomic (position-level) "
-                                "constraints. There are {} acceleration-level "
-                                "scalar constraints associated with the model "
-                                "Constraint at ConstraintIndex {}.",
-                            ma, cid));
+                    "Enforcing constraint derivatives is supported only for "
+                    "holonomic (position-level) constraints. There are {} "
+                    "acceleration-level scalar constraints associated with the "
+                    "model Constraint at ConstraintIndex {}.",
+                    ma, cid);
 
             total_mp += mp;
             total_mv += mv;
@@ -191,10 +189,10 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
                         OPENSIM_THROW_IF(
                                 multInfo.getName().substr(0, 6) != "lambda",
                                 Exception,
-                                fmt::format("Expected the multiplier name for "
-                                            "this constraint to begin with "
-                                            "'lambda' but it begins with '{}'.",
-                                        multInfo.getName().substr(0, 6)));
+                                "Expected the multiplier name for this "
+                                "constraint to begin with 'lambda' but it "
+                                "begins with '{}'.",
+                                multInfo.getName().substr(0, 6));
                         const auto vcBounds = convertBounds(
                                 mocoCasADiSolver
                                         .get_velocity_correction_bounds());

--- a/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/Moco/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -103,9 +103,8 @@ template <typename VectorType = SimTK::Vector>
 VectorType convertToSimTKVector(const casadi::DM& casVector) {
     OPENSIM_THROW_IF(casVector.columns() != 1 && casVector.rows() != 1,
             Exception,
-            fmt::format("casVector should be 1-dimensional, but has size {} x "
-                        "{}.",
-                    casVector.rows(), casVector.columns()));
+            "casVector should be 1-dimensional, but has size {} x {}.",
+            casVector.rows(), casVector.columns());
     VectorType simtkVector((int)casVector.numel());
     for (int i = 0; i < casVector.numel(); ++i) {
         simtkVector[i] = double(casVector(i));

--- a/Moco/Moco/MocoConstraintInfo.h
+++ b/Moco/Moco/MocoConstraintInfo.h
@@ -126,9 +126,9 @@ private:
     void checkPropertySize(const AbstractProperty& prop) {
         if (!prop.empty()) {
             OPENSIM_THROW_IF(m_num_equations != prop.size(), Exception,
-                    fmt::format("Size of property {} is not consistent with "
-                           "current number of constraint equations.",
-                            prop.getName()));
+                    "Size of property {} is not consistent with "
+                    "current number of constraint equations.",
+                    prop.getName());
         }
     }
 };

--- a/Moco/Moco/MocoControlBoundConstraint.cpp
+++ b/Moco/Moco/MocoControlBoundConstraint.cpp
@@ -57,8 +57,9 @@ void MocoControlBoundConstraint::initializeOnModelImpl(
             const auto& thisName = get_control_paths(i);
             OPENSIM_THROW_IF_FRMOBJ(systemControlIndexMap.count(thisName) == 0,
                     Exception,
-                    fmt::format("Control path '{}' was provided but no such "
-                                "control exists in the model.", thisName));
+                    "Control path '{}' was provided but no such "
+                    "control exists in the model.",
+                    thisName);
             m_controlIndices.push_back(systemControlIndexMap[thisName]);
         }
     }
@@ -73,16 +74,16 @@ void MocoControlBoundConstraint::initializeOnModelImpl(
         if (auto* spline = dynamic_cast<const GCVSpline*>(&f)) {
             OPENSIM_THROW_IF_FRMOBJ(
                     spline->getMinX() > problemInfo.minInitialTime, Exception,
-                    fmt::format("The function's minimum domain value ({}) must "
-                           "be less than or equal to the minimum possible "
-                           "initial time ({}).",
-                            spline->getMinX(), problemInfo.minInitialTime));
+                    "The function's minimum domain value ({}) must "
+                    "be less than or equal to the minimum possible "
+                    "initial time ({}).",
+                    spline->getMinX(), problemInfo.minInitialTime);
             OPENSIM_THROW_IF_FRMOBJ(
                     spline->getMaxX() < problemInfo.maxFinalTime, Exception,
-                    fmt::format("The function's maximum domain value ({}) must "
-                           "be greater than or equal to the maximum possible "
-                           "final time ({}).",
-                            spline->getMaxX(), problemInfo.maxFinalTime));
+                    "The function's maximum domain value ({}) must "
+                    "be greater than or equal to the maximum possible "
+                    "final time ({}).",
+                    spline->getMaxX(), problemInfo.maxFinalTime);
         }
     };
     if (m_hasLower) checkTimeRange(get_lower_bound());

--- a/Moco/Moco/MocoFrameDistanceConstraint.cpp
+++ b/Moco/Moco/MocoFrameDistanceConstraint.cpp
@@ -63,28 +63,29 @@ void MocoFrameDistanceConstraint::initializeOnModelImpl(
     for (int i = 0; i < nFramePairs; ++i) {
         const auto frame1_path = get_frame_pairs(i).get_frame1_path();
         OPENSIM_THROW_IF(!model.hasComponent<Frame>(frame1_path), Exception,
-                fmt::format("Could not find frame '{}'.", frame1_path));
+                "Could not find frame '{}'.", frame1_path);
         auto& frame1 = model.getComponent<Frame>(frame1_path);
         const auto frame2_path = get_frame_pairs(i).get_frame2_path();
         OPENSIM_THROW_IF(!model.hasComponent<Frame>(frame2_path), Exception,
-                fmt::format("Could not find frame '{}'.", frame2_path));
+                "Could not find frame '{}'.", frame2_path);
         auto& frame2 = model.getComponent<Frame>(frame2_path);
         m_frame_pairs.emplace_back(&frame1, &frame2);
 
         const double& minimum = get_frame_pairs(i).get_minimum_distance();
         const double& maximum = get_frame_pairs(i).get_maximum_distance();
         OPENSIM_THROW_IF(minimum < 0, Exception,
-                fmt::format("Expected the minimum distance for this frame pair "
-                            "to non-negative, but it is {}.",
-                        minimum));
+                "Expected the minimum distance for this frame pair to "
+                "non-negative, but it is {}.",
+                minimum);
         OPENSIM_THROW_IF(maximum < 0, Exception,
-                fmt::format("Expected the maximum distance for this frame pair "
-                            "to non-negative, but it is {}.", maximum));
+                "Expected the maximum distance for this frame pair "
+                "to non-negative, but it is {}.",
+                maximum);
         OPENSIM_THROW_IF(minimum > maximum, Exception,
-                fmt::format("Expected the minimum distance for this frame pair "
-                            "to be less than or equal to the maximum distance, "
-                            "but they are {} and {}, respectively.",
-                        minimum, maximum));
+                "Expected the minimum distance for this frame pair "
+                "to be less than or equal to the maximum distance, "
+                "but they are {} and {}, respectively.",
+                minimum, maximum);
         bounds.emplace_back(SimTK::square(minimum), SimTK::square(maximum));
     }
 
@@ -94,10 +95,10 @@ void MocoFrameDistanceConstraint::initializeOnModelImpl(
     } else if (get_projection() == "plane") {
         m_projectionType = ProjectionType::Plane;
     } else if (get_projection() != "none") {
-        OPENSIM_THROW_FRMOBJ(
-                Exception, fmt::format("Expected 'projection' to be 'none', "
-                                       "'vector', or 'plane', but got '{}'.",
-                                   get_projection()));
+        OPENSIM_THROW_FRMOBJ(Exception,
+                "Expected 'projection' to be 'none', 'vector', or 'plane', but "
+                "got '{}'.",
+                get_projection());
     }
     if (m_projectionType != ProjectionType::None) {
         OPENSIM_THROW_IF_FRMOBJ(getProperty_projection_vector().empty(),

--- a/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoAccelerationTrackingGoal.cpp
@@ -59,11 +59,10 @@ void MocoAccelerationTrackingGoal::initializeOnModelImpl(
                 OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
                                                 path) == labels.end(),
                         Exception,
-                        fmt::format("Expected frame_paths to match one of the "
-                                    "column labels in the acceleration "
-                                    "reference, but frame path '{}' not found "
-                                    "in the reference labels.",
-                                path));
+                        "Expected frame_paths to match one of the column "
+                        "labels in the acceleration reference, but frame path "
+                        "'{}' not found in the reference labels.",
+                        path);
                 m_frame_paths.push_back(path);
                 accelerationTable.appendColumn(path, 
                     accelerationTableToUse.getDependentColumn(path));

--- a/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.cpp
@@ -61,13 +61,10 @@ void MocoAngularVelocityTrackingGoal::initializeOnModelImpl(
                 OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
                                                 path) == labels.end(),
                         Exception,
-                        fmt::format(
-                                "Expected frame_paths to match one of the "
-                                "column labels in the angular velocity "
-                                "reference, but "
-                                "frame path '{}' not found in the reference "
-                                "labels.",
-                                path));
+                        "Expected frame_paths to match one of the column "
+                        "labels in the angular velocity reference, but frame "
+                        "path '{}' not found in the reference labels.",
+                        path);
                 m_frame_paths.push_back(path);
                 angularVelocityTable.appendColumn(path,
                         angularVelocityTableToUse.getDependentColumn(path));

--- a/Moco/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -113,8 +113,8 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
 
         OPENSIM_THROW_IF_FRMOBJ(
                 !extLoads->contains(group.get_external_force_name()), Exception,
-                fmt::format("External force '{}' not found.",
-                        group.get_external_force_name()));
+                "External force '{}' not found.",
+                group.get_external_force_name());
         const auto& extForce =
                 extLoads->get(group.get_external_force_name());
 
@@ -156,9 +156,8 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
                                 "./bodyset/" + forceExpressedInBody);
             } else {
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        fmt::format("Could not find '{}' in the model or "
-                                    "the BodySet.",
-                                forceExpressedInBody));
+                        "Could not find '{}' in the model or the BodySet.",
+                        forceExpressedInBody);
             }
         }
 
@@ -171,10 +170,10 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
     } else if (get_projection() == "plane") {
         m_projectionType = ProjectionType::Plane;
     } else if (get_projection() != "none") {
-        OPENSIM_THROW_FRMOBJ(
-                Exception, fmt::format("Expected 'projection' to be 'none', "
-                                       "'vector', or 'plane', but got '{}'.",
-                                   get_projection()));
+        OPENSIM_THROW_FRMOBJ(Exception,
+                "Expected 'projection' to be 'none', 'vector', or 'plane', but "
+                "got '{}'.",
+                get_projection());
     }
     if (m_projectionType != ProjectionType::None) {
         OPENSIM_THROW_IF_FRMOBJ(getProperty_projection_vector().empty(),
@@ -230,14 +229,12 @@ int MocoContactTrackingGoal::findRecordOffset(
     }
 
     OPENSIM_THROW_FRMOBJ(Exception,
-            fmt::format("Contact force '{}' has sphere base frame '{}' "
-                  "and half space base frame '{}'. One of these "
-                   "frames should match the applied_to_body "
-                   "setting ('{}') of ExternalForce '{}', or match one of "
-                   "the alternative_frame_paths, but no match found.",
-                    contactForce.getAbsolutePathString(),
-                    sphereBaseName, halfSpaceBaseName, appliedToBody,
-                    group.get_external_force_name()));
+            "Contact force '{}' has sphere base frame '{}' and half space base "
+            "frame '{}'. One of these frames should match the applied_to_body "
+            "setting ('{}') of ExternalForce '{}', or match one of the "
+            "alternative_frame_paths, but no match found.",
+            contactForce.getAbsolutePathString(), sphereBaseName,
+            halfSpaceBaseName, appliedToBody, group.get_external_force_name());
 }
 
 void MocoContactTrackingGoal::calcIntegrandImpl(

--- a/Moco/Moco/MocoGoal/MocoControlTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoControlTrackingGoal.cpp
@@ -47,8 +47,9 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& weightName = get_control_weights().get(i).getName();
         if (allControlIndices.count(weightName) == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    fmt::format("Weight provided with name '{}' but this is "
-                           "not a recognized control.", weightName));
+                    "Weight provided with name '{}' but this is "
+                    "not a recognized control.",
+                    weightName);
         }
     }
 
@@ -64,13 +65,12 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& controlName = get_reference_labels(i).getName();
         if (allControlIndices.count(controlName) == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                fmt::format("Control '{}' does not exist in the model.",
-                        controlName));
+                    "Control '{}' does not exist in the model.", controlName);
         }
         OPENSIM_THROW_IF_FRMOBJ(controlsToTrack.count(controlName), Exception,
-                fmt::format("Expected control '{}' to be provided no more "
-                            "than once, but it is provided more than once.",
-                        controlName));
+                "Expected control '{}' to be provided no more "
+                "than once, but it is provided more than once.",
+                controlName);
         controlsToTrack.insert(controlName);
         refLabels[controlName] = get_reference_labels(i).get_reference();
     }
@@ -89,10 +89,10 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
         for (const auto& control : controlsToTrack) {
             OPENSIM_THROW_IF_FRMOBJ(!allSplines.contains(refLabels[control]),
                     Exception,
-                    fmt::format("Expected reference to contain label '{}', "
-                                "which was associated with control '{}', but "
-                                "no such label exists.",
-                            refLabels[control], control));
+                    "Expected reference to contain label '{}', "
+                    "which was associated with control '{}', but "
+                    "no such label exists.",
+                    refLabels[control], control);
         }
     } else {
         // The goal is in 'auto' labeling mode;
@@ -102,10 +102,9 @@ void MocoControlTrackingGoal::initializeOnModelImpl(const Model& model) const {
             if (allControlIndices.count(refLabel) == 0) {
                 if (get_allow_unused_references()) { continue; }
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        fmt::format("Reference contains column '{}' which does "
-                                    "not match the name of any control "
-                                    "variables.",
-                                refLabel));
+                        "Reference contains column '{}' which does "
+                        "not match the name of any control variables.",
+                        refLabel);
             }
             // In this labeling mode, the refLabel is the control name.
             controlsToTrack.insert(refLabel);

--- a/Moco/Moco/MocoGoal/MocoControlTrackingGoal.h
+++ b/Moco/Moco/MocoGoal/MocoControlTrackingGoal.h
@@ -196,8 +196,7 @@ public:
             }
         }
         OPENSIM_THROW_FRMOBJ(Exception,
-                fmt::format("No reference label provided for control '{}'.",
-                        control));
+                "No reference label provided for control '{}'.", control);
     }
 
     bool getAllowUnusedReferences() const {

--- a/Moco/Moco/MocoGoal/MocoJointReactionGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoJointReactionGoal.cpp
@@ -80,8 +80,8 @@ void MocoJointReactionGoal::initializeOnModelImpl(const Model& model) const {
                         get_reaction_measures(i)) == allowedMeasures.end()) {
 
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        fmt::format("Reaction measure '{}' not recognized.",
-                                get_reaction_measures(i)));
+                        "Reaction measure '{}' not recognized.",
+                        get_reaction_measures(i));
             }
             reactionMeasures.push_back(get_reaction_measures(i));
         }

--- a/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoMarkerTrackingGoal.cpp
@@ -59,11 +59,9 @@ void MocoMarkerTrackingGoal::initializeOnModelImpl(const Model& model) const {
             m_refindices.push_back(i);
         } else {
             if (!get_allow_unused_references()) {
-                OPENSIM_THROW_FRMOBJ(
-                        Exception,
-                        fmt::format("Marker '{}' unrecognized by "
-                                    "the specified model.",
-                                markRefNames[i]));
+                OPENSIM_THROW_FRMOBJ(Exception,
+                        "Marker '{}' unrecognized by the specified model.",
+                        markRefNames[i]);
             }
         }
     }

--- a/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -58,13 +58,13 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
             const auto& labels = rotationTableToUse.getColumnLabels();
             for (int i = 0; i < getProperty_frame_paths().size(); ++i) {
                 const auto& path = get_frame_paths(i);
-                OPENSIM_THROW_IF_FRMOBJ(
-                    std::find(labels.begin(), labels.end(), path) ==
-                        labels.end(),
-                    Exception,
-                    fmt::format("Expected frame_paths to match one of the "
+                OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
+                                                path) == labels.end(),
+                        Exception,
+                        "Expected frame_paths to match one of the "
                         "column labels in the rotation reference, but frame "
-                        "path '{}' not found in the reference labels.", path));
+                        "path '{}' not found in the reference labels.",
+                        path);
                 m_frame_paths.push_back(path);
                 rotationTable.appendColumn(path,
                     rotationTableToUse.getDependentColumn(path));

--- a/Moco/Moco/MocoGoal/MocoPeriodicityGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoPeriodicityGoal.cpp
@@ -65,10 +65,10 @@ void MocoPeriodicityGoal::initializeOnModelImpl(const Model& model) const {
     for (int i = 0; i < nStatePairs; ++i) {
         const auto path1 = get_state_pairs(i).get_initial_variable();
         OPENSIM_THROW_IF(allSysYIndices.count(path1) == 0, Exception,
-                fmt::format("Could not find state '{}'.", path1));
+                "Could not find state '{}'.", path1);
         const auto path2 = get_state_pairs(i).get_final_variable();
         OPENSIM_THROW_IF(allSysYIndices.count(path2) == 0, Exception,
-                fmt::format("Could not find state '{}'.", path2));
+                "Could not find state '{}'.", path2);
         int stateIndex1 = allSysYIndices[path1];
         int stateIndex2 = allSysYIndices[path2];
         m_state_names.emplace_back(path1, path2);
@@ -82,10 +82,10 @@ void MocoPeriodicityGoal::initializeOnModelImpl(const Model& model) const {
     for (int i = 0; i < nControlPairs; ++i) {
         const auto path1 = get_control_pairs(i).get_initial_variable();
         OPENSIM_THROW_IF(systemControlIndexMap.count(path1) == 0, Exception,
-                fmt::format("Could not find control '{}'.", path1));
+                "Could not find control '{}'.", path1);
         const auto path2 = get_control_pairs(i).get_final_variable();
         OPENSIM_THROW_IF(systemControlIndexMap.count(path2) == 0, Exception,
-                fmt::format("Could not find control '{}'.", path2));
+                "Could not find control '{}'.", path2);
         int controlIndex1 = systemControlIndexMap[path1];
         int controlIndex2 = systemControlIndexMap[path2];
         m_control_names.emplace_back(path1, path2);

--- a/Moco/Moco/MocoGoal/MocoStateTrackingGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoStateTrackingGoal.cpp
@@ -46,15 +46,16 @@ void MocoStateTrackingGoal::initializeOnModelImpl(const Model& model) const {
         const auto& weightName = get_state_weights().get(i).getName();
         if (allSysYIndices.count(weightName) == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                fmt::format("Weight provided with name '{}' but this is "
-                    "not a recognized state.", weightName));
+                    "Weight provided with name '{}' but this is "
+                    "not a recognized state.",
+                    weightName);
         }
         if (getProperty_pattern().size() &&
                 !std::regex_match(weightName, regex)) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    fmt::format("Weight provided with name '{}' but this name "
-                                "does not match the pattern '{}'.",
-                            weightName, get_pattern()));
+                    "Weight provided with name '{}' but this name "
+                    "does not match the pattern '{}'.",
+                    weightName, get_pattern());
         }
     }
 
@@ -67,19 +68,17 @@ void MocoStateTrackingGoal::initializeOnModelImpl(const Model& model) const {
             if (get_allow_unused_references()) {
                 continue;
             }
-            OPENSIM_THROW_FRMOBJ(Exception,
-                 fmt::format("State reference '{}' unrecognized.", refName));
+            OPENSIM_THROW_FRMOBJ(
+                    Exception, "State reference '{}' unrecognized.", refName);
         }
         if (getProperty_pattern().size() &&
                 !std::regex_match(refName, regex)) {
             if (get_allow_unused_references()) {
                 continue;
             }
-            OPENSIM_THROW_FRMOBJ(
-                    Exception,
-                    fmt::format("State reference '{}' does not match the "
-                                "pattern '{}'.",
-                            refName, get_pattern()));
+            OPENSIM_THROW_FRMOBJ(Exception,
+                    "State reference '{}' does not match the pattern '{}'.",
+                    refName, get_pattern());
         }
 
         m_sysYIndices.push_back(allSysYIndices[refName]);

--- a/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
+++ b/Moco/Moco/MocoGoal/MocoSumSquaredStateGoal.cpp
@@ -39,17 +39,17 @@ void MocoSumSquaredStateGoal::initializeOnModelImpl(const Model& model) const {
             const auto& weightName = get_state_weights().get(i).getName();
             if (allSysYIndices.count(weightName) == 0) {
                 OPENSIM_THROW_FRMOBJ(Exception,
-                        fmt::format("Weight provided with name '{}' "
-                        "but this is not a recognized state.", weightName));
+                        "Weight provided with name '{}' but this is not a "
+                        "recognized state.",
+                        weightName);
             }
 
             if (getProperty_pattern().size()) {
                 if (!std::regex_match(weightName, regex)) {
                     OPENSIM_THROW_FRMOBJ(Exception,
-                            fmt::format("Weight provided with name '{}' but "
-                                        "this name does not match the "
-                                        "pattern '{}'.",
-                                    weightName, get_pattern()));
+                            "Weight provided with name '{}' but this name does "
+                            "not match the pattern '{}'.",
+                            weightName, get_pattern());
                 }
             }
         }
@@ -71,8 +71,9 @@ void MocoSumSquaredStateGoal::initializeOnModelImpl(const Model& model) const {
         // Pattern must match at least one state.
         if (m_sysYIndices.size() == 0) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    fmt::format("Pattern '{}' given but no state variables "
-                           "matched the pattern.", get_pattern()));
+                    "Pattern '{}' given but no state variables "
+                    "matched the pattern.",
+                    get_pattern());
         }
     }
 

--- a/Moco/Moco/MocoParameter.cpp
+++ b/Moco/Moco/MocoParameter.cpp
@@ -102,25 +102,21 @@ void MocoParameter::initializeOnModel(Model& model) const {
                 Exception, "Must specify a property element for "
                 "non-scalar propeties.");
             OPENSIM_THROW_IF_FRMOBJ(get_property_element() < 0, Exception,
-                    fmt::format("Expected property element to be non-negative, "
-                                "but {} was provided.",
-                            get_property_element()));
+                    "Expected property element to be non-negative, but {} was "
+                    "provided.",
+                    get_property_element());
             if (dynamic_cast<Property<SimTK::Vec3>*>(ap)) {
                 OPENSIM_THROW_IF_FRMOBJ(get_property_element() > 2, Exception,
-                        fmt::format(
-                                "The property element for a Vec3 property must "
-                                "be between 0 and 2, but the value {} was "
-                                "provided.",
-                                get_property_element()));
+                        "The property element for a Vec3 property must be "
+                        "between 0 and 2, but the value {} was provided.",
+                        get_property_element());
                 m_data_type = Type_Vec3;
             }
             else if (dynamic_cast<Property<SimTK::Vec6>*>(ap)) {
                 OPENSIM_THROW_IF_FRMOBJ(get_property_element() > 5, Exception,
-                        fmt::format(
-                                "The property element for a Vec6 property must "
-                                "be between 0 and 5, but the value {} was "
-                                "provided.",
-                                get_property_element()));
+                        "The property element for a Vec6 property must be "
+                        "between 0 and 5, but the value {} was provided.",
+                        get_property_element());
                 m_data_type = Type_Vec6;
             }
             else {

--- a/Moco/Moco/MocoProblem.cpp
+++ b/Moco/Moco/MocoProblem.cpp
@@ -153,7 +153,7 @@ const MocoVariableInfo& MocoPhase::getStateInfo(const std::string& name) const {
 
     int idx = getProperty_state_infos().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No info available for state '{}'.", name));
+            "No info available for state '{}'.", name);
     return get_state_infos(idx);
 }
 const MocoVariableInfo& MocoPhase::getControlInfo(
@@ -161,35 +161,35 @@ const MocoVariableInfo& MocoPhase::getControlInfo(
 
     int idx = getProperty_control_infos().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No info available for control '{}'.", name));
+            "No info available for control '{}'.", name);
     return get_control_infos(idx);
 }
 const MocoParameter& MocoPhase::getParameter(const std::string& name) const {
 
     int idx = getProperty_parameters().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No parameter with name '{}' found.", name));
+            "No parameter with name '{}' found.", name);
     return get_parameters(idx);
 }
 MocoParameter& MocoPhase::updParameter(const std::string& name) {
 
     int idx = getProperty_parameters().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No parameter with name '{}' found.", name));
+            "No parameter with name '{}' found.", name);
     return upd_parameters(idx);
 }
 const MocoGoal& MocoPhase::getGoal(const std::string& name) const {
 
     int idx = getProperty_goals().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No goal with name '{}' found.", name));
+            "No goal with name '{}' found.", name);
     return get_goals(idx);
 }
 MocoGoal& MocoPhase::updGoal(const std::string& name) {
 
     int idx = updProperty_goals().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No goal with name '{}' found.", name));
+            "No goal with name '{}' found.", name);
     return upd_goals(idx);
 }
 const MocoPathConstraint& MocoPhase::getPathConstraint(
@@ -197,14 +197,14 @@ const MocoPathConstraint& MocoPhase::getPathConstraint(
 
     int idx = getProperty_path_constraints().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No path constraint with name '{}' found.", name));
+            "No path constraint with name '{}' found.", name);
     return get_path_constraints(idx);
 }
 MocoPathConstraint& MocoPhase::updPathConstraint(const std::string& name) {
 
     int idx = updProperty_path_constraints().findIndexForName(name);
     OPENSIM_THROW_IF_FRMOBJ(idx == -1, Exception,
-            fmt::format("No path constraint with name '{}' found.", name));
+            "No path constraint with name '{}' found.", name);
     return upd_path_constraints(idx);
 }
 

--- a/Moco/Moco/MocoProblemRep.cpp
+++ b/Moco/Moco/MocoProblemRep.cpp
@@ -292,8 +292,7 @@ void MocoProblemRep::initialize() {
     for (int i = 0; i < ph0.getProperty_state_infos().size(); ++i) {
         const auto& name = ph0.get_state_infos(i).getName();
         OPENSIM_THROW_IF(stateNames.findIndex(name) == -1, Exception,
-                fmt::format("State info provided for nonexistent state '{}'.",
-                        name));
+                "State info provided for nonexistent state '{}'.", name);
     }
 
     // Create internal record of state and control infos, automatically
@@ -380,9 +379,9 @@ void MocoProblemRep::initialize() {
         const auto& name = ph0.get_control_infos(i).getName();
         auto it = std::find(controlNames.begin(), controlNames.end(), name);
         OPENSIM_THROW_IF(it == controlNames.end(), Exception,
-                fmt::format("Control info provided for nonexistent or disabled "
-                            "actuator '{}'.",
-                        name));
+                "Control info provided for nonexistent or disabled actuator "
+                "'{}'.",
+                name);
     }
 
     for (int i = 0; i < ph0.getProperty_control_infos().size(); ++i) {
@@ -471,8 +470,7 @@ void MocoProblemRep::initialize() {
         OPENSIM_THROW_IF(param.getName().empty(), Exception,
                 "All parameters must have a name.");
         OPENSIM_THROW_IF(paramNames.count(param.getName()), Exception,
-                fmt::format("A parameter with name '{}' already exists.",
-                        param.getName()));
+                "A parameter with name '{}' already exists.", param.getName());
         paramNames.insert(param.getName());
         m_parameters[i] = std::unique_ptr<MocoParameter>(param.clone());
         // We must initialize on both models so that they are consistent
@@ -493,8 +491,7 @@ void MocoProblemRep::initialize() {
         OPENSIM_THROW_IF(goal.getName().empty(), Exception,
                 "All goals must have a name.");
         OPENSIM_THROW_IF(goalNames.count(goal.getName()), Exception,
-                fmt::format("A goal with name '{}' already exists.",
-                        goal.getName()));
+                "A goal with name '{}' already exists.", goal.getName());
         goalNames.insert(goal.getName());
         if (goal.getEnabled()) {
             std::unique_ptr<MocoGoal> item(goal.clone());
@@ -521,8 +518,8 @@ void MocoProblemRep::initialize() {
         OPENSIM_THROW_IF(pc.getName().empty(), Exception,
                 "All path constraints must have a name.");
         OPENSIM_THROW_IF(pcNames.count(pc.getName()), Exception,
-                fmt::format("A path constraint with name '{}' already exists.",
-                        pc.getName()));
+                "A path constraint with name '{}' already exists.",
+                pc.getName());
         pcNames.insert(pc.getName());
         m_path_constraints[i] = std::unique_ptr<MocoPathConstraint>(pc.clone());
         m_path_constraints[i]->initializeOnModel(m_model_disabled_constraints,
@@ -638,13 +635,13 @@ std::vector<std::string> MocoProblemRep::createPathConstraintNames() const {
 const MocoVariableInfo& MocoProblemRep::getStateInfo(
         const std::string& name) const {
     OPENSIM_THROW_IF(m_state_infos.count(name) == 0, Exception,
-            fmt::format("No info available for state '{}'.", name));
+            "No info available for state '{}'.", name);
     return m_state_infos.at(name);
 }
 const MocoVariableInfo& MocoProblemRep::getControlInfo(
         const std::string& name) const {
     OPENSIM_THROW_IF(m_control_infos.count(name) == 0, Exception,
-            fmt::format("No info available for control '{}'.", name));
+            "No info available for control '{}'.", name);
     return m_control_infos.at(name);
 }
 const MocoParameter& MocoProblemRep::getParameter(
@@ -653,16 +650,14 @@ const MocoParameter& MocoProblemRep::getParameter(
     for (const auto& param : m_parameters) {
         if (param->getName() == name) { return *param.get(); }
     }
-    OPENSIM_THROW(
-            Exception, fmt::format("No parameter with name '{}' found.", name));
+    OPENSIM_THROW(Exception, "No parameter with name '{}' found.", name);
 }
 const MocoGoal& MocoProblemRep::getCost(const std::string& name) const {
 
     for (const auto& c : m_costs) {
         if (c->getName() == name) { return *c.get(); }
     }
-    OPENSIM_THROW(
-            Exception, fmt::format("No cost with name '{}' found.", name));
+    OPENSIM_THROW(Exception, "No cost with name '{}' found.", name);
 }
 const MocoGoal& MocoProblemRep::getCostByIndex(int index) const {
     return *m_costs[index];
@@ -673,8 +668,8 @@ const MocoGoal& MocoProblemRep::getEndpointConstraint(
     for (const auto& c : m_endpoint_constraints) {
         if (c->getName() == name) { return *c.get(); }
     }
-    OPENSIM_THROW(Exception,
-            fmt::format("No endpoint constraint with name '{}' found.", name));
+    OPENSIM_THROW(
+            Exception, "No endpoint constraint with name '{}' found.", name);
 }
 const MocoGoal& MocoProblemRep::getEndpointConstraintByIndex(int index) const {
     return *m_endpoint_constraints[index];
@@ -685,8 +680,7 @@ const MocoPathConstraint& MocoProblemRep::getPathConstraint(
     for (const auto& pc : m_path_constraints) {
         if (pc->getName() == name) { return *pc.get(); }
     }
-    OPENSIM_THROW(Exception,
-            fmt::format("No path constraint with name '{}' found.", name));
+    OPENSIM_THROW(Exception, "No path constraint with name '{}' found.", name);
 }
 const MocoPathConstraint& MocoProblemRep::getPathConstraintByIndex(
         int index) const {
@@ -700,8 +694,8 @@ const MocoKinematicConstraint& MocoProblemRep::getKinematicConstraint(
     for (const auto& kc : m_kinematic_constraints) {
         if (kc.getConstraintInfo().getName() == name) { return kc; }
     }
-    OPENSIM_THROW(Exception,
-            fmt::format("No kinematic constraint with name '{}' found.", name));
+    OPENSIM_THROW(
+            Exception, "No kinematic constraint with name '{}' found.", name);
 }
 const std::vector<MocoVariableInfo>& MocoProblemRep::getMultiplierInfos(
         const std::string& kinematicConstraintInfoName) const {
@@ -710,10 +704,10 @@ const std::vector<MocoVariableInfo>& MocoProblemRep::getMultiplierInfos(
     if (search != m_multiplier_infos_map.end()) {
         return m_multiplier_infos_map.at(kinematicConstraintInfoName);
     } else {
-        OPENSIM_THROW(Exception, fmt::format("No variable infos for kinematic "
-                                             "constraint info with "
-                                             "name '{}' found.",
-                                         kinematicConstraintInfoName));
+        OPENSIM_THROW(Exception,
+                "No variable infos for kinematic constraint info with name "
+                "'{}' found.",
+                kinematicConstraintInfoName);
     }
 }
 
@@ -722,9 +716,9 @@ void MocoProblemRep::applyParametersToModelProperties(
         bool initSystemAndDisableConstraints) const {
     OPENSIM_THROW_IF(parameterValues.size() != (int)m_parameters.size(),
             Exception,
-            fmt::format("There are {} parameters in "
-                        "this MocoProblem, but {} values were provided.",
-                    m_parameters.size(), parameterValues.size()));
+            "There are {} parameters in this MocoProblem, but {} values were "
+            "provided.",
+            m_parameters.size(), parameterValues.size());
     for (int i = 0; i < (int)m_parameters.size(); ++i) {
         m_parameters[i]->applyParameterToModelProperties(parameterValues(i));
     }

--- a/Moco/Moco/MocoSolver.cpp
+++ b/Moco/Moco/MocoSolver.cpp
@@ -28,10 +28,10 @@ MocoTrajectory MocoSolver::createGuessTimeStepping() const {
     const auto& initialTime = probrep.getTimeInitialBounds().getUpper();
     const auto& finalTime = probrep.getTimeFinalBounds().getLower();
     OPENSIM_THROW_IF_FRMOBJ(finalTime <= initialTime, Exception,
-            fmt::format("Expected lower bound on final time to be greater than "
-                        "upper bound on initial time, but "
-                        "final_time.lower: {}; initial_time.upper: {}.",
-                    finalTime, initialTime));
+            "Expected lower bound on final time to be greater than "
+            "upper bound on initial time, but "
+            "final_time.lower: {}; initial_time.upper: {}.",
+            finalTime, initialTime);
     Model model(probrep.getModelBase());
 
     // Disable all controllers?

--- a/Moco/Moco/MocoTool.cpp
+++ b/Moco/Moco/MocoTool.cpp
@@ -36,30 +36,30 @@ void MocoTool::updateTimeInfo(const std::string& dataLabel,
     double final;
     if (!getProperty_initial_time().empty()) {
         OPENSIM_THROW_IF_FRMOBJ(get_initial_time() < dataInitial, Exception,
-                fmt::format("Provided initial time of {} is less than what is "
-                            "available from {} data, which starts at {}.",
-                        get_initial_time(), dataLabel, dataInitial));
+                "Provided initial time of {} is less than what is "
+                "available from {} data, which starts at {}.",
+                get_initial_time(), dataLabel, dataInitial);
         initial = get_initial_time();
     } else {
         initial = std::max(info.initial, dataInitial);
     }
     if (!getProperty_final_time().empty()) {
         OPENSIM_THROW_IF_FRMOBJ(get_final_time() > dataFinal, Exception,
-                fmt::format("Provided final time of {} is greater than what "
-                            "is available from {} data, which ends at {}.",
-                        get_final_time(), dataLabel, dataFinal));
+                "Provided final time of {} is greater than what "
+                "is available from {} data, which ends at {}.",
+                get_final_time(), dataLabel, dataFinal);
         final = get_final_time();
     } else {
         final = std::min(info.final, dataFinal);
     }
 
     OPENSIM_THROW_IF_FRMOBJ(final < initial, Exception,
-            fmt::format("Initial time of {} is greater than final time of {}.",
-                    initial, final));
+            "Initial time of {} is greater than final time of {}.", initial,
+            final);
 
     OPENSIM_THROW_IF_FRMOBJ(get_mesh_interval() <= 0, Exception,
-            fmt::format("Expected mesh_interval to be positive but got {}.",
-                    get_mesh_interval()));
+            "Expected mesh_interval to be positive but got {}.",
+            get_mesh_interval());
 
     info.initial = initial;
     info.final = final;

--- a/Moco/Moco/MocoTrack.cpp
+++ b/Moco/Moco/MocoTrack.cpp
@@ -71,7 +71,7 @@ MocoStudy MocoTrack::initialize() {
     } else {
         OPENSIM_THROW_IF(get_apply_tracked_states_to_guess(), Exception,
                 "Property 'apply_tracked_states_to_guess' was enabled, but no "
-                "states reference data was provided.")
+                "states reference data was provided.");
     }
 
     // Marker tracking cost.
@@ -86,9 +86,9 @@ MocoStudy MocoTrack::initialize() {
     // ----------------------------
     if (get_minimize_control_effort()) {
         OPENSIM_THROW_IF(get_control_effort_weight() < 0, Exception,
-                fmt::format("Expected a non-negative control effort weight, "
-                            "but got a weight with value {}.",
-                        get_control_effort_weight()));
+                "Expected a non-negative control effort weight, "
+                "but got a weight with value {}.",
+                get_control_effort_weight());
 
         auto* effort = problem.addGoal<MocoControlGoal>("control_effort");
         effort->setWeight(get_control_effort_weight());
@@ -280,9 +280,9 @@ void MocoTrack::applyStatesToGuess(
             guess.setState(label, col);
         } else {
             OPENSIM_THROW_IF(!get_allow_unused_references(), Exception,
-                    fmt::format("Tried to apply data for state '{}' to guess, "
-                                "but this state does not exist in the model.",
-                            label));
+                    "Tried to apply data for state '{}' to guess, "
+                    "but this state does not exist in the model.",
+                    label);
         }
     }
 }

--- a/Moco/Moco/MocoTrajectory.cpp
+++ b/Moco/Moco/MocoTrajectory.cpp
@@ -74,23 +74,22 @@ MocoTrajectory::MocoTrajectory(const SimTK::Vector& time,
             Exception, "Inconsistent number of multipliers.");
     if (m_states.ncol()) {
         OPENSIM_THROW_IF(time.size() != m_states.nrow(), Exception,
-                fmt::format("Expected states to have {} rows but it has {}.",
-                        time.size(), m_states.nrow()));
+                "Expected states to have {} rows but it has {}.", time.size(),
+                m_states.nrow());
     } else {
         m_states.resize(m_time.size(), 0);
     }
     if (m_controls.ncol()) {
         OPENSIM_THROW_IF(time.size() != m_controls.nrow(), Exception,
-                fmt::format("Expected controls to have {} rows but it has {}.",
-                        time.size(), m_controls.nrow()));
+                "Expected controls to have {} rows but it has {}.", time.size(),
+                m_controls.nrow());
     } else {
         m_controls.resize(m_time.size(), 0);
     }
     if (m_multipliers.ncol()) {
         OPENSIM_THROW_IF(time.size() != m_multipliers.nrow(), Exception,
-                fmt::format("Expected multipliers to have {} rows but it has "
-                            "{}.",
-                        time.size(), m_multipliers.nrow()));
+                "Expected multipliers to have {} rows but it has {}.",
+                time.size(), m_multipliers.nrow());
     } else {
         m_multipliers.resize(m_time.size(), 0);
     }
@@ -153,8 +152,7 @@ MocoTrajectory::MocoTrajectory(const SimTK::Vector& time,
 void MocoTrajectory::setTime(const SimTK::Vector& time) {
     ensureUnsealed();
     OPENSIM_THROW_IF(time.size() != m_time.size(), Exception,
-            fmt::format("Expected {} times but got {}.", m_time.size(),
-                    time.size()));
+            "Expected {} times but got {}.", m_time.size(), time.size());
     m_time = time;
 }
 
@@ -162,12 +160,12 @@ void MocoTrajectory::setState(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_states.nrow(), Exception,
-            fmt::format("For state {}, expected {} elements but got {}.", name,
-                    m_states.nrow(), trajectory.size()));
+            "For state {}, expected {} elements but got {}.", name,
+            m_states.nrow(), trajectory.size());
 
     auto it = std::find(m_state_names.cbegin(), m_state_names.cend(), name);
     OPENSIM_THROW_IF(it == m_state_names.cend(), Exception,
-            fmt::format("Cannot find state named {}.", name));
+            "Cannot find state named {}.", name);
     int index = (int)std::distance(m_state_names.cbegin(), it);
     m_states.updCol(index) = trajectory;
 }
@@ -176,12 +174,12 @@ void MocoTrajectory::setControl(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_controls.nrow(), Exception,
-            fmt::format("For control {}, expected {} elements but got {}.",
-                    name, m_controls.nrow(), trajectory.size()));
+            "For control {}, expected {} elements but got {}.", name,
+            m_controls.nrow(), trajectory.size());
 
     auto it = std::find(m_control_names.cbegin(), m_control_names.cend(), name);
     OPENSIM_THROW_IF(it == m_control_names.cend(), Exception,
-            fmt::format("Cannot find control named {}.", name));
+            "Cannot find control named {}.", name);
     int index = (int)std::distance(m_control_names.cbegin(), it);
     m_controls.updCol(index) = trajectory;
 }
@@ -190,13 +188,13 @@ void MocoTrajectory::setMultiplier(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_multipliers.nrow(), Exception,
-            fmt::format("For multiplier {}, expected {} elements but got {}.",
-                    name, m_multipliers.nrow(), trajectory.size()));
+            "For multiplier {}, expected {} elements but got {}.", name,
+            m_multipliers.nrow(), trajectory.size());
 
     auto it = std::find(
             m_multiplier_names.cbegin(), m_multiplier_names.cend(), name);
     OPENSIM_THROW_IF(it == m_multiplier_names.cend(), Exception,
-            fmt::format("Cannot find multiplier named {}.", name));
+            "Cannot find multiplier named {}.", name);
     int index = (int)std::distance(m_multiplier_names.cbegin(), it);
     m_multipliers.updCol(index) = trajectory;
 }
@@ -205,13 +203,13 @@ void MocoTrajectory::setDerivative(
         const std::string& name, const SimTK::Vector& trajectory) {
     ensureUnsealed();
     OPENSIM_THROW_IF(trajectory.size() != m_derivatives.nrow(), Exception,
-            fmt::format("For derivative {}, expected {} elements but got {}.",
-                    name, m_derivatives.nrow(), trajectory.size()));
+            "For derivative {}, expected {} elements but got {}.", name,
+            m_derivatives.nrow(), trajectory.size());
 
     auto it = std::find(
             m_derivative_names.cbegin(), m_derivative_names.cend(), name);
     OPENSIM_THROW_IF(it == m_derivative_names.cend(), Exception,
-            fmt::format("Cannot find derivative named {}.", name));
+            "Cannot find derivative named {}.", name);
     int index = (int)std::distance(m_derivative_names.cbegin(), it);
     m_derivatives.updCol(index) = trajectory;
 
@@ -222,12 +220,12 @@ void MocoTrajectory::setSlack(
     ensureUnsealed();
 
     OPENSIM_THROW_IF(trajectory.size() != m_slacks.nrow(), Exception,
-            fmt::format("For slack {}, expected {} elements but got {}.", name,
-                    m_slacks.nrow(), trajectory.size()));
+            "For slack {}, expected {} elements but got {}.", name,
+            m_slacks.nrow(), trajectory.size());
 
     auto it = std::find(m_slack_names.cbegin(), m_slack_names.cend(), name);
     OPENSIM_THROW_IF(it == m_slack_names.cend(), Exception,
-            fmt::format("Cannot find slack named {}.", name));
+            "Cannot find slack named {}.", name);
     int index = (int)std::distance(m_slack_names.cbegin(), it);
     m_slacks.updCol(index) = trajectory;
 }
@@ -239,10 +237,9 @@ void MocoTrajectory::appendSlack(
     OPENSIM_THROW_IF(m_time.nrow() == 0, Exception,
             "The time vector must be set before adding slack variables.");
     OPENSIM_THROW_IF(trajectory.size() != m_time.nrow(), Exception,
-            fmt::format("Attempted to add slack {} of length {}, but it is "
-                        "incompatible with the time vector, which has length "
-                        "{}.",
-                    name, trajectory.size(), m_time.nrow()));
+            "Attempted to add slack {} of length {}, but it is incompatible "
+            "with the time vector, which has length {}.",
+            name, trajectory.size(), m_time.nrow());
 
     m_slack_names.push_back(name);
     m_slacks.resizeKeep(m_time.nrow(), m_slacks.ncol() + 1);
@@ -256,7 +253,7 @@ void MocoTrajectory::setParameter(
     auto it = std::find(
             m_parameter_names.cbegin(), m_parameter_names.cend(), name);
     OPENSIM_THROW_IF(it == m_parameter_names.cend(), Exception,
-            fmt::format("Cannot find parameter named {}.", name));
+            "Cannot find parameter named {}.", name);
     int index = (int)std::distance(m_parameter_names.cbegin(), it);
     m_parameters.updElt(0, index) = value;
 }
@@ -275,9 +272,9 @@ void MocoTrajectory::setStatesTrajectory(const TimeSeriesTable& states,
         for (const auto& trajectory_state : m_state_names) {
             OPENSIM_THROW_IF(find(labels, trajectory_state) == labels.end(),
                     Exception,
-                    fmt::format("Expected table to contain column '{}'; "
-                                "consider setting allowMissingColumns to true.",
-                            trajectory_state));
+                    "Expected table to contain column '{}'; consider setting "
+                    "allowMissingColumns to true.",
+                    trajectory_state);
         }
     }
 
@@ -288,10 +285,9 @@ void MocoTrajectory::setStatesTrajectory(const TimeSeriesTable& states,
         } else {
             if (!allowExtraColumns) {
                 OPENSIM_THROW(Exception,
-                        fmt::format("Column '{}' is not a state in the "
-                                    "trajectory; consider setting "
-                                    "allowExtraColumns to true.",
-                                label));
+                        "Column '{}' is not a state in the trajectory; "
+                        "consider setting allowExtraColumns to true.",
+                        label);
             }
         }
     }
@@ -508,7 +504,7 @@ SimTK::VectorView MocoTrajectory::getState(const std::string& name) const {
     ensureUnsealed();
     auto it = std::find(m_state_names.cbegin(), m_state_names.cend(), name);
     OPENSIM_THROW_IF(it == m_state_names.cend(), Exception,
-            fmt::format("Cannot find state named {}.", name));
+            "Cannot find state named {}.", name);
     int index = (int)std::distance(m_state_names.cbegin(), it);
     return m_states.col(index);
 }
@@ -516,7 +512,7 @@ SimTK::VectorView MocoTrajectory::getControl(const std::string& name) const {
     ensureUnsealed();
     auto it = std::find(m_control_names.cbegin(), m_control_names.cend(), name);
     OPENSIM_THROW_IF(it == m_control_names.cend(), Exception,
-            fmt::format("Cannot find control named {}.", name));
+            "Cannot find control named {}.", name);
     int index = (int)std::distance(m_control_names.cbegin(), it);
     return m_controls.col(index);
 }
@@ -525,7 +521,7 @@ SimTK::VectorView MocoTrajectory::getMultiplier(const std::string& name) const {
     auto it = std::find(
             m_multiplier_names.cbegin(), m_multiplier_names.cend(), name);
     OPENSIM_THROW_IF(it == m_multiplier_names.cend(), Exception,
-            fmt::format("Cannot find multiplier named {}.", name));
+            "Cannot find multiplier named {}.", name);
     int index = (int)std::distance(m_multiplier_names.cbegin(), it);
     return m_multipliers.col(index);
 }
@@ -534,7 +530,7 @@ SimTK::VectorView MocoTrajectory::getDerivative(const std::string& name) const {
     auto it = std::find(
             m_derivative_names.cbegin(), m_derivative_names.cend(), name);
     OPENSIM_THROW_IF(it == m_derivative_names.cend(), Exception,
-            fmt::format("Cannot find derivative named {}.", name));
+            "Cannot find derivative named {}.", name);
     int index = (int)std::distance(m_derivative_names.cbegin(), it);
     return m_derivatives.col(index);
 }
@@ -542,7 +538,7 @@ SimTK::VectorView MocoTrajectory::getSlack(const std::string& name) const {
     ensureUnsealed();
     auto it = std::find(m_slack_names.cbegin(), m_slack_names.cend(), name);
     OPENSIM_THROW_IF(it == m_slack_names.cend(), Exception,
-            fmt::format("Cannot find slack named {}.", name));
+            "Cannot find slack named {}.", name);
     int index = (int)std::distance(m_slack_names.cbegin(), it);
     return m_slacks.col(index);
 }
@@ -551,7 +547,7 @@ const SimTK::Real& MocoTrajectory::getParameter(const std::string& name) const {
     auto it = std::find(
             m_parameter_names.cbegin(), m_parameter_names.cend(), name);
     OPENSIM_THROW_IF(it == m_parameter_names.cend(), Exception,
-            fmt::format("Cannot find parameter named {}.", name));
+            "Cannot find parameter named {}.", name);
     int index = (int)std::distance(m_parameter_names.cbegin(), it);
     return m_parameters.getElt(0, index);
 }
@@ -587,19 +583,18 @@ void MocoTrajectory::resample(SimTK::Vector time) {
     OPENSIM_THROW_IF(m_time.size() < 2, Exception,
             "Cannot resample if number of times is 0 or 1.");
     OPENSIM_THROW_IF(time[0] < m_time[0], Exception,
-            fmt::format("New initial time ({}) cannot be less than existing "
-                        "initial time ({})",
-                    time[0], m_time[0]));
+            "New initial time ({}) cannot be less than existing initial time "
+            "({})",
+            time[0], m_time[0]);
     OPENSIM_THROW_IF(time[time.size() - 1] > m_time[m_time.size() - 1],
             Exception,
-            fmt::format("New final time ({}) cannot be less than existing "
-                        "final time ({})",
-                    time[time.size() - 1], m_time[m_time.size() - 1]));
+            "New final time ({}) cannot be less than existing final time ({})",
+            time[time.size() - 1], m_time[m_time.size() - 1]);
     for (int itime = 1; itime < time.size(); ++itime) {
         OPENSIM_THROW_IF(time[itime] < time[itime - 1], Exception,
-                fmt::format("New times must be non-decreasing, but "
-                            "time[{}] < time[{}] ({} < {}).",
-                        itime, itime - 1, time[itime], time[itime - 1]));
+                "New times must be non-decreasing, but time[{}] < time[{}] "
+                "({} < {}).",
+                itime, itime - 1, time[itime], time[itime - 1]);
     }
 
     int numStates = (int)m_state_names.size();
@@ -730,15 +725,14 @@ MocoTrajectory::MocoTrajectory(const std::string& filepath) {
                                      numSlacks + numParameters !=
                              (int)table.getNumColumns(),
             Exception,
-            fmt::format(
-                    "Expected num_states + num_controls + num_multipliers + "
-                    "num_derivatives + num_slacks + num_parameters = "
-                    "number of columns, but "
-                    "num_states={}, num_controls={}, "
-                    "num_multipliers={}, num_derivatives={}, num_slacks={}, "
-                    "num_parameters={}, number of columns={}.",
-                    numStates, numControls, numMultipliers, numDerivatives,
-                    numSlacks, numParameters, table.getNumColumns()));
+            "Expected num_states + num_controls + num_multipliers + "
+            "num_derivatives + num_slacks + num_parameters = "
+            "number of columns, but "
+            "num_states={}, num_controls={}, "
+            "num_multipliers={}, num_derivatives={}, num_slacks={}, "
+            "num_parameters={}, number of columns={}.",
+            numStates, numControls, numMultipliers, numDerivatives, numSlacks,
+            numParameters, table.getNumColumns());
 
     const auto& time = table.getIndependentColumn();
     m_time = SimTK::Vector((int)time.size(), time.data());
@@ -948,19 +942,18 @@ void MocoTrajectory::randomize(bool add, const SimTK::Random& randGen) {
     const int statesNumRows = (int)statesTrajectory.getNumRows();
     const int controlsNumRows = (int)controlsTrajectory.getNumRows();
     OPENSIM_THROW_IF(statesNumRows != controlsNumRows, Exception,
-            fmt::format("Expected statesTrajectory ({} rows) and "
-                        "controlsTrajectory ({} rows) to have the same number "
-                        "of rows.",
-                    statesNumRows, controlsNumRows));
+            "Expected statesTrajectory ({} rows) and controlsTrajectory ({} "
+            "rows) to have the same number of rows.",
+            statesNumRows, controlsNumRows);
     // TODO interpolate instead of creating this error.
     for (int i = 0; i < statesNumRows; ++i) {
         const auto& statesTime = statesTrajectory.getIndependentColumn()[i];
         const auto& controlsTime = controlsTrajectory.getIndependentColumn()[i];
         OPENSIM_THROW_IF(statesTime != controlsTime, Exception,
-                fmt::format("Expected time columns of statesTrajectory and "
-                            "controlsTrajectory to match, but they differ at i "
-                            "= {} (states time: {}; controls time: {}).",
-                        i, statesTime, controlsTime));
+                "Expected time columns of statesTrajectory and "
+                "controlsTrajectory to match, but they differ at i "
+                "= {} (states time: {}; controls time: {}).",
+                i, statesTime, controlsTime);
     }
 
     // TODO Support controlsTrajectory being empty.
@@ -1275,7 +1268,7 @@ double MocoTrajectory::compareContinuousVariablesRMS(
     ensureUnsealed();
     for (auto kv : cols) {
         OPENSIM_THROW_IF(find(m_allowedKeys, kv.first) == m_allowedKeys.cend(),
-                Exception, fmt::format("Key '{}' is not allowed.", kv.first));
+                Exception, "Key '{}' is not allowed.", kv.first);
     }
     if (cols.size() == 0) {
         return compareContinuousVariablesRMSInternal(other);
@@ -1302,8 +1295,8 @@ double MocoTrajectory::compareContinuousVariablesRMSPattern(
     } else if (columnType == "derivatives") {
         names = &m_derivative_names;
     } else {
-        OPENSIM_THROW(Exception,
-                fmt::format("Column type '{}' is not allowed.", columnType));
+        OPENSIM_THROW(
+                Exception, "Column type '{}' is not allowed.", columnType);
     }
     std::vector<std::string> namesToUse;
     std::regex regex(pattern);
@@ -1366,8 +1359,7 @@ double MocoSolution::getObjectiveTerm(const std::string& name) const {
             return entry.second;
         }
     }
-    OPENSIM_THROW(
-            Exception, fmt::format("Objective term '{}' not found.", name));
+    OPENSIM_THROW(Exception, "Objective term '{}' not found.", name);
 }
 
 double MocoSolution::getObjectiveTermByIndex(int index) const {
@@ -1375,9 +1367,9 @@ double MocoSolution::getObjectiveTermByIndex(int index) const {
     OPENSIM_THROW_IF(
             index < 0, Exception, "Expected index to be non-negative.");
     OPENSIM_THROW_IF(index >= (int)m_objectiveBreakdown.size(), Exception,
-            fmt::format("Expected index ({}) to be less than the number of "
-                        "objective terms ({}).",
-                    index, m_objectiveBreakdown.size()));
+            "Expected index ({}) to be less than the number of "
+            "objective terms ({}).",
+            index, m_objectiveBreakdown.size());
     return m_objectiveBreakdown[index].second;
 }
 

--- a/Moco/Moco/MocoTropterSolver.cpp
+++ b/Moco/Moco/MocoTropterSolver.cpp
@@ -90,11 +90,10 @@ MocoTropterSolver::createTropterSolver(
         OPENSIM_THROW_IF(get_transcription_scheme() != "hermite-simpson" &&
                                  get_enforce_constraint_derivatives(),
                 Exception,
-                fmt::format("If enforcing derivatives of model kinematic "
-                       "constraints, then the property 'transcription_scheme' "
-                       "must be set to 'hermite-simpson'. "
-                       "Currently, it is set to '{}'.",
-                        get_transcription_scheme()));
+                "If enforcing derivatives of model kinematic constraints, then "
+                "the property 'transcription_scheme' must be set to "
+                "'hermite-simpson'. Currently, it is set to '{}'.",
+                get_transcription_scheme());
     }
     OPENSIM_THROW_IF_FRMOBJ(
             getProblemRep().getNumImplicitAuxiliaryResiduals(),
@@ -215,9 +214,9 @@ MocoTrajectory MocoTropterSolver::createGuess(const std::string& type) const {
     OPENSIM_THROW_IF_FRMOBJ(
             type != "bounds" && type != "random" && type != "time-stepping",
             Exception,
-            fmt::format("Unexpected guess type '{}'; supported types are "
-                   "'bounds', 'random', and 'time-stepping'.",
-                    type));
+            "Unexpected guess type '{}'; supported types are "
+            "'bounds', 'random', and 'time-stepping'.",
+            type);
 
     if (type == "time-stepping") { return createGuessTimeStepping(); }
 

--- a/Moco/Moco/MocoUtilities.cpp
+++ b/Moco/Moco/MocoUtilities.cpp
@@ -106,9 +106,9 @@ SimTK::Vector OpenSim::interpolate(const SimTK::Vector& x,
         const bool ignoreNaNs) {
 
     OPENSIM_THROW_IF(x.size() != y.size(), Exception,
-            fmt::format("Expected size of x to equal size of y, but size of x "
-                        "is {} and size of y is {}.",
-                    x.size(), y.size()));
+            "Expected size of x to equal size of y, but size of x "
+            "is {} and size of y is {}.",
+            x.size(), y.size());
 
     // Create vectors of non-NaN values if user set 'ignoreNaNs' argument to
     // 'true', otherwise throw an exception. If no NaN's are present in the
@@ -199,8 +199,7 @@ void OpenSim::updateStateLabels40(const Model& model,
 TimeSeriesTable OpenSim::filterLowpass(
         const TimeSeriesTable& table, double cutoffFreq, bool padData) {
     OPENSIM_THROW_IF(cutoffFreq < 0, Exception,
-            fmt::format("Cutoff frequency must be non-negative; got {}.",
-                    cutoffFreq));
+            "Cutoff frequency must be non-negative; got {}.", cutoffFreq);
     auto storage = convertTableToStorage(table);
     if (padData) { storage.pad((int)table.getNumRows() / 2); }
     storage.lowpassIIR(cutoffFreq);
@@ -418,8 +417,8 @@ void OpenSim::prescribeControlsToModel(
         } else if (functionType == "PiecewiseLinearFunction") {
             function = createFunction<PiecewiseLinearFunction>(time, control);
         } else {
-            OPENSIM_THROW(Exception,
-                    fmt::format("Unexpected function type {}.", functionType));
+            OPENSIM_THROW(
+                    Exception, "Unexpected function type {}.", functionType);
         }
         const auto& actu = model.getComponent<Actuator>(actuNames[i]);
         controller->addActuator(actu);
@@ -637,7 +636,7 @@ void OpenSim::checkRedundantLabels(std::vector<std::string> labels) {
     std::sort(labels.begin(), labels.end());
     auto it = std::adjacent_find(labels.begin(), labels.end());
     OPENSIM_THROW_IF(it != labels.end(), Exception,
-            fmt::format("Label '{}' appears more than once.", *it));
+            "Label '{}' appears more than once.", *it);
 }
 
 void OpenSim::checkLabelsMatchModelStates(const Model& model,
@@ -645,11 +644,10 @@ void OpenSim::checkLabelsMatchModelStates(const Model& model,
     const auto modelStateNames = model.getStateVariableNames();
     for (const auto& label : labels) {
         OPENSIM_THROW_IF(modelStateNames.rfindIndex(label) == -1, Exception,
-                fmt::format(
-                        "Expected the provided labels to match the model state "
-                        "names, but label {} does not correspond to any model "
-                        "state.",
-                        label));
+                "Expected the provided labels to match the model state "
+                "names, but label {} does not correspond to any model "
+                "state.",
+                label);
     }
 }
 
@@ -730,10 +728,9 @@ MocoTrajectory OpenSim::createPeriodicTrajectory(
                             std::regex_replace(name, regex, pattern.second);
                     const auto it = find(names, opposite);
                     OPENSIM_THROW_IF(it == names.end(), Exception,
-                            fmt::format(
                                     "Could not find {} {}, which is supposed "
                                     "to be opposite of {}.",
-                                    vartype, opposite, name));
+                                    vartype, opposite, name);
                     const int iopp = (int)std::distance(names.cbegin(), it);
                     newTraj.updBlock(oldN, iopp, oldN - 1, 1) =
                             oldTraj.block(1, i, oldN - 1, 1);
@@ -850,8 +847,8 @@ SimTK::Real OpenSim::solveBisection(
     SimTK::Real midpoint = left;
 
     OPENSIM_THROW_IF(maxIterations < 0, Exception,
-            fmt::format("Expected maxIterations to be positive, but got {}.",
-                    maxIterations));
+            "Expected maxIterations to be positive, but got {}.",
+            maxIterations);
 
     const bool sameSign = calcResidual(left) * calcResidual(right) >= 0;
     if (sameSign) {
@@ -866,8 +863,7 @@ SimTK::Real OpenSim::solveBisection(
         // writeTableToFile(table, "DEBUG_solveBisection_residual.sto");
     }
     OPENSIM_THROW_IF(sameSign, Exception,
-            fmt::format("Function has same sign at bounds of {} and {}.", left,
-                    right));
+            "Function has same sign at bounds of {} and {}.", left, right);
 
     SimTK::Real residualMidpoint;
     SimTK::Real residualLeft = calcResidual(left);

--- a/Moco/Moco/MocoVariableInfo.cpp
+++ b/Moco/Moco/MocoVariableInfo.cpp
@@ -42,25 +42,25 @@ void MocoVariableInfo::validate() const {
     const auto fb = getFinalBounds();
 
     OPENSIM_THROW_IF(ib.isSet() && ib.getLower() < b.getLower(), Exception,
-            fmt::format("For variable {}, expected "
-                   "[initial value lower bound] >= [lower bound], but "
-                   "intial value lower bound={}, lower bound={}.",
-                    n, ib.getLower(), b.getLower()));
+            "For variable {}, expected "
+            "[initial value lower bound] >= [lower bound], but "
+            "intial value lower bound={}, lower bound={}.",
+            n, ib.getLower(), b.getLower());
     OPENSIM_THROW_IF(fb.isSet() && fb.getLower() < b.getLower(), Exception,
-            fmt::format("For variable {}, expected "
-                   "[final value lower bound] >= [lower bound], but "
-                   "final value lower bound={}, lower bound={}.",
-                    n, fb.getLower(), b.getLower()));
+            "For variable {}, expected "
+            "[final value lower bound] >= [lower bound], but "
+            "final value lower bound={}, lower bound={}.",
+            n, fb.getLower(), b.getLower());
     OPENSIM_THROW_IF(ib.isSet() && ib.getUpper() > b.getUpper(), Exception,
-            fmt::format("For variable {}, expected "
-                   "[initial value upper bound] >= [upper bound], but "
-                   "initial value upper bound={}, upper bound={}.",
-                    n, ib.getUpper(), b.getUpper()));
+            "For variable {}, expected "
+            "[initial value upper bound] >= [upper bound], but "
+            "initial value upper bound={}, upper bound={}.",
+            n, ib.getUpper(), b.getUpper());
     OPENSIM_THROW_IF(fb.isSet() && fb.getUpper() > b.getUpper(), Exception,
-            fmt::format("For variable {}, expected "
-                   "[final value upper bound] >= [upper bound], but "
-                   "final value upper bound={}, upper bound={}.",
-                    n, fb.getUpper(), b.getUpper()));
+            "For variable {}, expected "
+            "[final value upper bound] >= [upper bound], but "
+            "final value upper bound={}, upper bound={}.",
+            n, fb.getUpper(), b.getUpper());
 }
 
 void MocoVariableInfo::printDescription() const {

--- a/Moco/Moco/ModelOperators.h
+++ b/Moco/Moco/ModelOperators.h
@@ -83,10 +83,10 @@ public:
     ModOpTendonComplianceDynamicsModeDGF(std::string mode) : 
             ModOpTendonComplianceDynamicsModeDGF() {
         OPENSIM_THROW_IF(mode != "explicit" && mode != "implicit", Exception,
-                fmt::format("The tendon compliance dynamics mode must be "
-                            "either 'explicit' or 'implicit', but {} was "
-                            "provided.",
-                        mode));
+                "The tendon compliance dynamics mode must be "
+                "either 'explicit' or 'implicit', but {} was "
+                "provided.",
+                mode);
         set_mode(std::move(mode));
     }
     void operate(Model& model, const std::string&) const override {

--- a/Moco/Moco/tropter/TropterProblem.h
+++ b/Moco/Moco/tropter/TropterProblem.h
@@ -174,19 +174,17 @@ protected:
             // constraint derivatives? For now, disallow enforcing derivatives
             // if non-holonomic or acceleration constraints present.
             OPENSIM_THROW_IF(enforceConstraintDerivs && mv != 0, Exception,
-                    fmt::format("Enforcing constraint derivatives is supported "
-                                "only for holonomic (position-level) "
-                                "constraints. There are {} velocity-level "
-                                "scalar constraints associated with the model "
-                                "Constraint at ConstraintIndex {}.",
-                            mv, cid));
+                    "Enforcing constraint derivatives is supported "
+                    "only for holonomic (position-level) constraints. There "
+                    "are {} velocity-level scalar constraints associated with "
+                    "the model Constraint at ConstraintIndex {}.",
+                    mv, cid);
             OPENSIM_THROW_IF(enforceConstraintDerivs && ma != 0, Exception,
-                    fmt::format("Enforcing constraint derivatives is supported "
-                                "only for holonomic (position-level) "
-                                "constraints. There are {} acceleration-level "
-                                "scalar constraints associated with the model "
-                                "Constraint at ConstraintIndex {}.",
-                            ma, cid));
+                    "Enforcing constraint derivatives is supported only for "
+                    "holonomic (position-level) constraints. There are {} "
+                    "acceleration-level scalar constraints associated with the "
+                    "model Constraint at ConstraintIndex {}.",
+                    ma, cid);
 
             m_total_mp += mp;
             m_total_mv += mv;
@@ -229,10 +227,10 @@ protected:
                         OPENSIM_THROW_IF(
                                 multInfo.getName().substr(0, 6) != "lambda",
                                 Exception,
-                                fmt::format("Expected the multiplier name for "
-                                            "this constraint to begin with "
-                                            "'lambda' but it begins with '{}'.",
-                                        multInfo.getName().substr(0, 6)));
+                                "Expected the multiplier name for "
+                                "this constraint to begin with "
+                                "'lambda' but it begins with '{}'.",
+                                multInfo.getName().substr(0, 6));
                         this->add_diffuse(std::string(multInfo.getName())
                                                   .replace(0, 6, "gamma"),
                                 convertBounds(

--- a/Moco/Sandbox/sandboxSandbox.cpp
+++ b/Moco/Sandbox/sandboxSandbox.cpp
@@ -21,6 +21,17 @@
 
 #include <Moco/osimMoco.h>
 
+using namespace OpenSim;
+
 int main() {
+    // TODO Logger::setLevel(Logger::Level::Debug);
+    MocoTrack track;
+    ModelProcessor modelProcessor("DeMers_mod_noarms_welds_4.0.osim");
+    modelProcessor.append(ModOpReplaceMusclesWithDeGrooteFregly2016());
+    modelProcessor.append(ModOpIgnoreTendonCompliance());
+    track.setModel(modelProcessor);
+    track.setStatesReference({"r_SLD_mean_coords.sto"});
+    track.set_allow_unused_references(true);
+    MocoSolution solution = track.solve();
     return EXIT_SUCCESS;
 }

--- a/dependencies/opensim-core.cmake
+++ b/dependencies/opensim-core.cmake
@@ -4,7 +4,7 @@
 # will invalidate its cached opensim-core installation if we change the commit.
 # This commented commit hash is not actually used in the superbuild.
 # opensim-core commit:
-# 82ec3d1c74af1ff1893d9c5453ef6c52fe2e2fc9
+# b0222c20bba068aa1abedde4b7d3ac7fba221629
 
 AddDependency(NAME       opensim-core
               URL        ${CMAKE_SOURCE_DIR}/../opensim-core


### PR DESCRIPTION
### Brief summary of changes

Take advantage of https://github.com/opensim-org/opensim-core/pull/2795 to avoid explicitly calling `fmt::format()` when throwing exceptions.
### CHANGELOG.md (choose one)

- [x] no need to update because...not user-facing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/646)
<!-- Reviewable:end -->
