### PR TITLE
Fix error in passive force length integral for DGF muscle

### DIFF
--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.cpp
@@ -1022,19 +1022,6 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
         std::string actname = actu->getName();
         model.addForce(actu.release());
 
-        // Workaround for a bug in prependComponentPathToConnecteePath().
-        for (auto& comp : model.updComponentList()) {
-            const auto& socketNames = comp.getSocketNames();
-            for (const auto& socketName : socketNames) {
-                auto& socket = comp.updSocket(socketName);
-                auto connecteePath = socket.getConnecteePath();
-                std::string prefix = "/forceset/" + actname;
-                if (startsWith(connecteePath, prefix)) {
-                    connecteePath = connecteePath.substr(prefix.length());
-                    socket.setConnecteePath(connecteePath);
-                }
-            }
-        }
         musclesToDelete.push_back(&muscBase);
     }
 

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.h
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.h
@@ -428,10 +428,13 @@ public:
 
         const double& e0 = get_passive_fiber_strain_at_one_norm_force();
 
-        const double temp1 = exp(kPE * m_minNormFiberLength / e0);
-        const double denom = exp(kPE * (1.0 + 1.0 / e0)) - temp1;
-        const double temp2 = kPE / e0 * normFiberLength;
-        return (e0 / kPE * exp(temp2) - normFiberLength * temp1) / denom;
+        const double temp1 = exp(kPE * normFiberLength / e0);
+        const double temp2 = exp(kPE * m_minNormFiberLength / e0);
+        const double temp3 = exp(kPE * (e0 + 1.0) / e0);
+        const double numer = -e0 * temp1 + kPE * normFiberLength * temp2;
+        const double denom = kPE * (temp2 - temp3);
+
+        return numer / denom;
     }
 
     /// The normalized tendon force as a function of normalized tendon length.

--- a/Moco/Moco/Components/DeGrooteFregly2016Muscle.h
+++ b/Moco/Moco/Components/DeGrooteFregly2016Muscle.h
@@ -303,6 +303,16 @@ public:
     /// Output functions.
     SimTK::Vec2 getBoundsNormalizedTendonForce(const SimTK::State&) const
     { return {getMinNormalizedTendonForce(), getMaxNormalizedTendonForce()}; }
+
+    static double getMinNormalizedFiberLength() { return m_minNormFiberLength; }
+    static double getMaxNormalizedFiberLength() { return m_maxNormFiberLength; }
+    /// The first element of the Vec2 is the lower bound, and the second is the
+    /// upper bound. 
+    /// Note that since fiber length is not used as a state variable, these 
+    /// bounds cannot be enforced directly. It is upon the user to ensure the 
+    /// muscle fiber is operating within the specified domain.
+    SimTK::Vec2 getBoundsNormalizedFiberLength() const 
+    { return {getMinNormalizedTendonForce(), getMaxNormalizedTendonForce()}; }
     /// @}
 
     /// @name Set methods.
@@ -420,7 +430,9 @@ public:
     }
 
     /// This is the integral of the passive force-length curve with respect to
-    /// the normalized fiber length.
+    /// the normalized fiber length over the domain 
+    /// [minNormFiberLength normFiberLength], where minNormFiberLength is the 
+    /// value return by getMinNormalizedFiberLength(). 
     SimTK::Real calcPassiveForceMultiplierIntegral(
             const SimTK::Real& normFiberLength) const {
 
@@ -428,13 +440,14 @@ public:
 
         const double& e0 = get_passive_fiber_strain_at_one_norm_force();
 
-        const double temp1 = exp(kPE * normFiberLength / e0);
-        const double temp2 = exp(kPE * m_minNormFiberLength / e0);
-        const double temp3 = exp(kPE * (e0 + 1.0) / e0);
-        const double numer = -e0 * temp1 + kPE * normFiberLength * temp2;
-        const double denom = kPE * (temp2 - temp3);
+        const double temp1 = 
+            e0 + kPE * normFiberLength - kPE * m_minNormFiberLength;
+        const double temp2 = exp(kPE * (normFiberLength - 1.0) / e0);
+        const double temp3 = exp(kPE * (m_minNormFiberLength - 1.0) / e0);
+        const double numer = exp(kPE) * temp1 - e0 * temp2;
+        const double denom = kPE * (temp3 - exp(kPE));
 
-        return numer / denom;
+        return (temp1 / kPE) + (numer / denom);
     }
 
     /// The normalized tendon force as a function of normalized tendon length.
@@ -454,11 +467,21 @@ public:
     }
 
     /// This is the integral of the tendon-force length curve with respect to
-    /// normalized tendon length.
+    /// normalized tendon length over the domain 
+    /// [minNormTendonLength normTendonLength]. The lower bound on the domain
+    /// is computed by passing the value return by getMinNormalizedTendonForce()
+    /// to calcTendonForceLengthInverseCurve(). 
     SimTK::Real calcTendonForceMultiplierIntegral(
             const SimTK::Real& normTendonLength) const {
-        return (c1 * exp(-m_kT * (c2 - normTendonLength))) / m_kT -
-               c3 * normTendonLength;
+
+        const double minNormTendonLength =
+                calcTendonForceLengthInverseCurve(m_minNormTendonForce);
+        const double temp1 =
+                exp(m_kT * normTendonLength) - exp(m_kT * minNormTendonLength);
+        const double temp2 = c1 * exp(-c2 * m_kT) / m_kT;
+        const double temp3 = c3 * (normTendonLength - minNormTendonLength);
+
+        return temp1 * temp2 - temp3;
     }
 
     /// This is the inverse of the tendon force-length curve, and returns the

--- a/Moco/Sandbox/DeGrooteFregly2016MuscleDerivatives.m
+++ b/Moco/Sandbox/DeGrooteFregly2016MuscleDerivatives.m
@@ -1,4 +1,4 @@
-syms b1 b2 b3 b4 lMtilde min_lMtilde c1 c2 c3 lTtilde kT kPE e0
+syms b1 b2 b3 b4 lMtilde min_lMtilde c1 c2 c3 lTtilde min_lTtilde kT kPE e0 
 
 fprintf('Derivative of tendon force length curve \n')
 fprintf('======================================= \n')
@@ -9,8 +9,18 @@ simplify(diff(f_t, lTtilde))
 fprintf('Integral of tendon force length curve \n')
 fprintf('===================================== \n')
 
-f_t = c1*exp(kT*(lTtilde - c2)) - c3;
-simplify(int(f_t, lTtilde))
+f_ten = c1*exp(kT*(lTtilde - c2)) - c3;
+f_ten_int = simplify(int(f_t, lTtilde, [min_lTtilde, lTtilde]));
+pretty(f_ten_int)
+
+% The same tendon force-length curve integral, now written as in the
+% DeGrooteFregly2016Muscle class where the full expression is decomposed into
+% multiple parts.
+temp1 = exp(kT * lTtilde) - exp(kT * min_lTtilde);
+temp2 = c1 * exp(-c2 * kT) / kT;
+temp3 = c3 * (lTtilde - min_lTtilde);
+f_ten_int_decomposed = temp1 * temp2 - temp3;
+assert(isequal(f_ten_int, f_ten_int_decomposed), 'Expressions not equal!');
 
 fprintf('Derivative of active fiber force length curve \n')
 fprintf('============================================= \n')
@@ -28,22 +38,29 @@ f_pas = (exp(kPE * (lMtilde - 1.0) / e0) - offset) / denom;
 f_pas_deriv = diff(f_pas, lMtilde);
 simplify(f_pas_deriv)
 
+% The same passive fiber force-length curve derivative, now written as in the
+% DeGrooteFregly2016Muscle class where the full expression is decomposed into
+% multiple parts.
 offset = exp(kPE * (min_lMtilde - 1.0) / e0);
-f_pas_deriv_decomp = (kPE * exp((kPE * (lMtilde - 1)) / e0)) / (e0 * (exp(kPE) - offset));
+f_pas_deriv_decomposed = ...
+    (kPE * exp((kPE * (lMtilde - 1)) / e0)) / (e0 * (exp(kPE) - offset));
 
-assert(isequal(f_pas_deriv, f_pas_deriv_decomp), 'Expressions not equal!');
+assert(isequal(f_pas_deriv, f_pas_deriv_decomposed), 'Expressions not equal!');
 
 fprintf('Integral of passive fiber force length curve \n')
 fprintf('============================================ \n')
 
-f_pas_int = simplify(int(f_pas, lMtilde));
+f_pas_int = simplify(int(f_pas, lMtilde, [min_lMtilde, lMtilde]));
 pretty(f_pas_int)
 
-temp1 = exp(kPE * lMtilde / e0);
-temp2 = exp(kPE * min_lMtilde / e0);
-temp3 = exp(kPE * (e0 + 1.0) / e0);
-numer = - e0 * temp1 + kPE * lMtilde * temp2;
-denom = kPE * (temp2 - temp3);
-f_pas_int_decomp = numer / denom;
+% The same passive fiber force-length curve integral, now written as in the
+% DeGrooteFregly2016Muscle class where the full expression is decomposed into
+% multiple parts.
+temp1 = e0 + kPE * lMtilde - kPE * min_lMtilde;
+temp2 = exp(kPE * (lMtilde - 1.0) / e0);
+temp3 = exp(kPE * (min_lMtilde - 1.0) / e0);
+numer = exp(kPE) * temp1 - e0 * temp2;
+denom = kPE * (temp3 - exp(kPE));
+f_pas_int_decomposed = (temp1 / kPE) + (numer / denom);
 
-assert(isequal(f_pas_int, f_pas_int_decomp), 'Expressions not equal!');
+assert(isequal(f_pas_int, f_pas_int_decomposed), 'Expressions not equal!');

--- a/Moco/Sandbox/DeGrooteFregly2016MuscleDerivatives.m
+++ b/Moco/Sandbox/DeGrooteFregly2016MuscleDerivatives.m
@@ -6,6 +6,12 @@ fprintf('======================================= \n')
 f_t = c1*exp(kT*(lTtilde - c2)) - c3;
 simplify(diff(f_t, lTtilde))
 
+fprintf('Integral of tendon force length curve \n')
+fprintf('===================================== \n')
+
+f_t = c1*exp(kT*(lTtilde - c2)) - c3;
+simplify(int(f_t, lTtilde))
+
 fprintf('Derivative of active fiber force length curve \n')
 fprintf('============================================= \n')
 
@@ -15,18 +21,29 @@ simplify(diff(f_act, lMtilde))
 fprintf('Derivative of passive fiber force length curve \n')
 fprintf('============================================== \n')
 
-f_pas = (exp(kPE * (lMtilde - 1.0) / e0) - exp(kPE * (min_lMtilde - 1) / e0)) / ...
-        (exp(kPE) - exp(kPE * (min_lMtilde - 1) / e0));
-simplify(diff(f_pas, lMtilde))
+offset = exp(kPE * (min_lMtilde - 1.0) / e0);
+denom = exp(kPE) - offset;
+f_pas = (exp(kPE * (lMtilde - 1.0) / e0) - offset) / denom;
 
-fprintf('Integral of tendon force length curve \n')
-fprintf('===================================== \n')
+f_pas_deriv = diff(f_pas, lMtilde);
+simplify(f_pas_deriv)
 
-f_t = c1*exp(kT*(lTtilde - c2)) - c3;
-simplify(int(f_t, lTtilde))
+offset = exp(kPE * (min_lMtilde - 1.0) / e0);
+f_pas_deriv_decomp = (kPE * exp((kPE * (lMtilde - 1)) / e0)) / (e0 * (exp(kPE) - offset));
+
+assert(isequal(f_pas_deriv, f_pas_deriv_decomp), 'Expressions not equal!');
 
 fprintf('Integral of passive fiber force length curve \n')
 fprintf('============================================ \n')
 
-f_pas_int = simplify(int(f_pas, lMtilde))
+f_pas_int = simplify(int(f_pas, lMtilde));
 pretty(f_pas_int)
+
+temp1 = exp(kPE * lMtilde / e0);
+temp2 = exp(kPE * min_lMtilde / e0);
+temp3 = exp(kPE * (e0 + 1.0) / e0);
+numer = - e0 * temp1 + kPE * lMtilde * temp2;
+denom = kPE * (temp2 - temp3);
+f_pas_int_decomp = numer / denom;
+
+assert(isequal(f_pas_int, f_pas_int_decomp), 'Expressions not equal!');


### PR DESCRIPTION
### Brief summary of changes
Fixed the method of DeGrooteFregly2016Muscle that calculates the integral of the passive fiber multiplier. 

### Details (optional)
- Updated the sandbox file for computing DGF muscle derivatives and integrals to add some checks to make sure our Moco implementation matches the Matlab symbolic expressions. (Not sure if we should consider adding a real test somewhere).

### CHANGELOG.md (choose one)

- [ ] updated
- [x] no need to update because...minor fix that only affected muscle fiber potential energy calculations. Did not change interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/647)
<!-- Reviewable:end -->
