### PR TITLE
[WIP]: Huber loss function

### DIFF
--- a/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
+++ b/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
@@ -68,7 +68,6 @@ void gaitTrackingMetabolics() {
     Bhargava2004Metabolics* metabolics = new Bhargava2004Metabolics();
     metabolics->setName("metabolics");
     metabolics->set_use_tanh_smoothing(true);
-    //metabolics->set_use_force_dependent_shortening_prop_constant(true);
     metabolics->addMuscle("hamstrings_r",
             baseModel.getComponent<Muscle>("hamstrings_r"));
     metabolics->addMuscle("hamstrings_l",
@@ -112,7 +111,7 @@ void gaitTrackingMetabolics() {
     track.setModel(modelprocessor);
     track.setStatesReference(
             TableProcessor("referenceCoordinates.sto") | TabOpLowPassFilter(6));
-    track.set_states_global_tracking_weight(10.0);
+    track.set_states_global_tracking_weight(30.0);
     track.set_allow_unused_references(true);
     track.set_track_reference_position_derivatives(true);
     track.set_apply_tracked_states_to_guess(true);
@@ -213,7 +212,7 @@ void gaitTrackingMetabolics() {
     solver.set_optim_convergence_tolerance(1e-4);
     solver.set_optim_constraint_tolerance(1e-4);
     solver.set_optim_max_iterations(10000);
-    solver.set_parallel(4);
+    solver.set_parallel(8);
 
     // Solve problem.
     // ==============

--- a/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
+++ b/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
@@ -67,7 +67,8 @@ void gaitTrackingMetabolics() {
     // Add metabolics
     Bhargava2004Metabolics* metabolics = new Bhargava2004Metabolics();
     metabolics->setName("metabolics");
-    metabolics->set_use_tanh_smoothing(true);
+    metabolics->set_use_smoothing(true);
+    metabolics->set_smoothing_type("tanh");
     metabolics->addMuscle("hamstrings_r",
             baseModel.getComponent<Muscle>("hamstrings_r"));
     metabolics->addMuscle("hamstrings_l",
@@ -212,7 +213,6 @@ void gaitTrackingMetabolics() {
     solver.set_optim_convergence_tolerance(1e-4);
     solver.set_optim_constraint_tolerance(1e-4);
     solver.set_optim_max_iterations(10000);
-    solver.set_parallel(8);
 
     // Solve problem.
     // ==============

--- a/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
+++ b/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
@@ -68,7 +68,7 @@ void gaitTrackingMetabolics() {
     Bhargava2004Metabolics* metabolics = new Bhargava2004Metabolics();
     metabolics->setName("metabolics");
     metabolics->set_use_tanh_smoothing(true);
-    metabolics->set_use_force_dependent_shortening_prop_constant(true);
+    //metabolics->set_use_force_dependent_shortening_prop_constant(true);
     metabolics->addMuscle("hamstrings_r",
             baseModel.getComponent<Muscle>("hamstrings_r"));
     metabolics->addMuscle("hamstrings_l",
@@ -213,7 +213,7 @@ void gaitTrackingMetabolics() {
     solver.set_optim_convergence_tolerance(1e-4);
     solver.set_optim_constraint_tolerance(1e-4);
     solver.set_optim_max_iterations(10000);
-    solver.set_parallel(20);
+    solver.set_parallel(4);
 
     // Solve problem.
     // ==============

--- a/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
+++ b/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
@@ -67,7 +67,8 @@ void gaitTrackingMetabolics() {
     // Add metabolics
     Bhargava2004Metabolics* metabolics = new Bhargava2004Metabolics();
     metabolics->setName("metabolics");
-    metabolics->set_use_huber_loss(true);
+    metabolics->set_use_tanh_smoothing(true);
+    metabolics->set_use_force_dependent_shortening_prop_constant(true);
     metabolics->addMuscle("hamstrings_r",
             baseModel.getComponent<Muscle>("hamstrings_r"));
     metabolics->addMuscle("hamstrings_l",
@@ -212,6 +213,7 @@ void gaitTrackingMetabolics() {
     solver.set_optim_convergence_tolerance(1e-4);
     solver.set_optim_constraint_tolerance(1e-4);
     solver.set_optim_max_iterations(10000);
+    solver.set_parallel(20);
 
     // Solve problem.
     // ==============

--- a/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
+++ b/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
@@ -67,7 +67,7 @@ void gaitTrackingMetabolics() {
     // Add metabolics
     Bhargava2004Metabolics* metabolics = new Bhargava2004Metabolics();
     metabolics->setName("metabolics");
-    metabolics->set_use_smoothing(true);
+    metabolics->set_use_huber_loss(true);
     metabolics->addMuscle("hamstrings_r",
             baseModel.getComponent<Muscle>("hamstrings_r"));
     metabolics->addMuscle("hamstrings_l",

--- a/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
+++ b/Moco/Examples/C++/example2DWalking/example2DWalkingMetabolics.cpp
@@ -68,7 +68,6 @@ void gaitTrackingMetabolics() {
     Bhargava2004Metabolics* metabolics = new Bhargava2004Metabolics();
     metabolics->setName("metabolics");
     metabolics->set_use_smoothing(true);
-    metabolics->set_smoothing_type("tanh");
     metabolics->addMuscle("hamstrings_r",
             baseModel.getComponent<Muscle>("hamstrings_r"));
     metabolics->addMuscle("hamstrings_l",

--- a/Moco/Moco/Components/Bhargava2004Metabolics.cpp
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.cpp
@@ -179,7 +179,6 @@ void Bhargava2004Metabolics::extendFinalizeFromProperties() {
         m_tanh_conditional = [](const double& cond, const double& left,
                 const double& right, const double& smoothing, const int&) {
             const double smoothed_binary = 0.5 + 0.5 * tanh(smoothing * cond);
-            std::cout << "tanh" << std::endl;
             return left + (-left + right) * smoothed_binary;
         };
         if (get_smoothing_type().compare("tanh") == 0) {

--- a/Moco/Moco/Components/Bhargava2004Metabolics.cpp
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.cpp
@@ -424,6 +424,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
         //     fiberVelocity>0 as lengthening.
         // ---------------------------------------------------------
         double alpha;
+        // TODO
         if (get_use_force_dependent_shortening_prop_constant())
         {
             alpha = m_conditional(fiberVelocity,
@@ -437,7 +438,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
             // This simpler value of alpha comes from Frank Anderson's 1999
             // dissertation "A Dynamic Optimization Solution for a Complete
             // Cycle of Normal Gait".
-            alpha = m_conditional(fiberVelocity,
+            alpha = m_conditional(fiberVelocity + 1e-16,
                     0.25 * fiberForceTotal,
                     0,
                     get_velocity_smoothing(),

--- a/Moco/Moco/Components/Bhargava2004Metabolics.cpp
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.cpp
@@ -80,6 +80,7 @@ Bhargava2004Metabolics::Bhargava2004Metabolics()
     const double curveY[] = {0.5, 0.5, 1.0, 0.0, 0.0};
     m_fiberLengthDepCurve = PiecewiseLinearFunction(curvePoints, curveX,
             curveY, "defaultCurve");
+
 }
 
 // Add a muscle with default Bhargava2004Metabolics_MuscleParameters so that it
@@ -173,6 +174,7 @@ void Bhargava2004Metabolics::constructProperties()
     constructProperty_tanh_velocity_smoothing(10);
     constructProperty_power_smoothing(10);
     constructProperty_heat_rate_smoothing(10);
+
 }
 
 void Bhargava2004Metabolics::extendFinalizeFromProperties() {
@@ -224,6 +226,9 @@ void Bhargava2004Metabolics::extendFinalizeFromProperties() {
             }
         };
     }
+    OPENSIM_THROW_IF_FRMOBJ(get_use_tanh_smoothing() &&
+            get_use_huber_loss_smoothing(), Exception,
+            "use_tanh_smoothing and use_huber_loss_smoothing are both true.");
 }
 
 double Bhargava2004Metabolics::getTotalMetabolicRate(

--- a/Moco/Moco/Components/Bhargava2004Metabolics.cpp
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.cpp
@@ -80,7 +80,6 @@ Bhargava2004Metabolics::Bhargava2004Metabolics()
     const double curveY[] = {0.5, 0.5, 1.0, 0.0, 0.0};
     m_fiberLengthDepCurve = PiecewiseLinearFunction(curvePoints, curveX,
             curveY, "defaultCurve");
-
 }
 
 // Add a muscle with default Bhargava2004Metabolics_MuscleParameters so that it
@@ -174,7 +173,6 @@ void Bhargava2004Metabolics::constructProperties()
     constructProperty_tanh_velocity_smoothing(10);
     constructProperty_power_smoothing(10);
     constructProperty_heat_rate_smoothing(10);
-
 }
 
 void Bhargava2004Metabolics::extendFinalizeFromProperties() {

--- a/Moco/Moco/Components/Bhargava2004Metabolics.cpp
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.cpp
@@ -181,10 +181,10 @@ void Bhargava2004Metabolics::extendFinalizeFromProperties() {
             const double smoothed_binary = 0.5 + 0.5 * tanh(smoothing * cond);
             return left + (-left + right) * smoothed_binary;
         };
-        if (get_smoothing_type().compare("tanh") == 0) {
+        if (get_smoothing_type() == "tanh") {
             m_conditional = m_tanh_conditional;
 
-        } else if (get_smoothing_type().compare("huber") == 0) {
+        } else if (get_smoothing_type() == "huber") {
             m_conditional = [](const double& cond, const double& left,
                     const double& right, const double& smoothing,
                     const int& direction) {
@@ -418,11 +418,11 @@ void Bhargava2004Metabolics::calcMetabolicRate(
         // ---------------------------------------------------------
         double alpha;
         if (get_use_force_dependent_shortening_prop_constant()) {
-            // When using the Huber loss smoothing approach, we rely on a tanh
-            // approximation for the shortening heat rate when using the force
-            // dependent shortening proportional constant. This is motivated by
-            // the fact that the shortening heat rate is defined by linear
-            // functions but with different non-null constants of
+            // Even when using the Huber loss smoothing approach, we still rely
+            // on a tanh approximation for the shortening heat rate when using
+            // the force dependent shortening proportional constant. This is
+            // motivated by the fact that the shortening heat rate is defined
+            // by linear functions but with different non-zero constants of
             // proportionality for concentric and eccentric contractions. It is
             // therefore easier to smooth the transition between both
             // contraction types with a tanh function than with a Huber loss

--- a/Moco/Moco/Components/Bhargava2004Metabolics.cpp
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.cpp
@@ -173,7 +173,6 @@ void Bhargava2004Metabolics::constructProperties()
     constructProperty_power_smoothing(10);
     constructProperty_heat_rate_smoothing(10);
     constructProperty_huber_loss_delta(1);
-    constructProperty_huber_loss_direction(1);
 }
 
 void Bhargava2004Metabolics::extendFinalizeFromProperties() {
@@ -433,7 +432,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
                     0.157 * fiberForceTotal,
                     get_velocity_smoothing(),
                     get_huber_loss_delta(),
-                    get_huber_loss_direction());
+                    -1);
         } else {
             // This simpler value of alpha comes from Frank Anderson's 1999
             // dissertation "A Dynamic Optimization Solution for a Complete
@@ -443,7 +442,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
                     0,
                     get_velocity_smoothing(),
                     get_huber_loss_delta(),
-                    get_huber_loss_direction());
+                    -1);
         }
         shorteningHeatRate = -alpha * fiberVelocity;
 
@@ -460,7 +459,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
                     0,
                     get_velocity_smoothing(),
                     get_huber_loss_delta(),
-                    get_huber_loss_direction());
+                    -1);
         }
 
         // NAN CHECKING
@@ -491,7 +490,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
                         Edot_W_beforeClamp,
                         get_power_smoothing(),
                         get_huber_loss_delta(),
-                        get_huber_loss_direction());
+                        1);
                 shorteningHeatRate -= Edot_W_beforeClamp_smoothed;
             } else {
                 if (Edot_W_beforeClamp < 0)
@@ -517,7 +516,7 @@ void Bhargava2004Metabolics::calcMetabolicRate(
                         1.0 * muscleParameter.getMuscleMass(),
                         get_heat_rate_smoothing(),
                         get_huber_loss_delta(),
-                        get_huber_loss_direction());
+                        1);
             }
         } else {
             if (get_enforce_minimum_heat_rate_per_muscle()

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -193,8 +193,9 @@ public:
             "dependent shortening proportionality constant, a tanh "
             "approximation is used even when using the Huber loss smoothing "
             "approach. The smoothness of the transition of that tanh function "
-            "is determined by the tanh_velocity_smoothing parameter. The "
-            "larger the steeper the transition but the worse for optimization "
+            "is determined by the tanh_velocity_smoothing parameter. With the "
+            "tanh (Huber loss) function, the larger the steeper (smoother) "
+            "the transition but (and) the worse (better) for optimization "
             "(default is 10).");
      OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_velocity_smoothing, double,
             "The parameter that determines the smoothness of the transition "
@@ -206,17 +207,19 @@ public:
             "other conditions related to contraction type, the smoothness is "
             "determined by the velocity_smoothing parameter. The larger the "
             "steeper the transition but the worse for optimization "
-            "(default is 10)");
+            "(default is 10).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(power_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the condition "
-            "enforcing non-negative total power. The larger the steeper the "
-            "transition but the worse for optimization (default is 10).");
+            "enforcing non-negative total power. With the tanh (Huber loss) "
+            "function, the larger the steeper (smoother) the transition but "
+            "(and) the worse (better) for optimization (default is 10).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(heat_rate_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the condition "
             "enforcing total heat rate larger than 1 (W/kg) for a give muscle "
-            ". The larger the steeper the transition but the worse for "
+            ". With the tanh (Huber loss) function, the larger the steeper "
+            "(smoother) the transition but (and) the worse (better) for "
             "optimization (default is 10).");
     OpenSim_DECLARE_LIST_PROPERTY(
             muscle_parameters, Bhargava2004Metabolics_MuscleParameters,

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -177,14 +177,13 @@ public:
     OpenSim_DECLARE_PROPERTY(forbid_negative_total_power, bool,
             "Specify whether the total power for each muscle must remain  "
             "positive (default is true).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_tanh_smoothing, bool,
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_smoothing, bool,
             "An optional flag that allows the user to explicitly specify "
-            "whether a smooth approximation, using tanh functions, of the "
-            "metabolic energy model should be used (default is false).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_huber_loss_smoothing, bool,
+            "whether a smooth approximation of the metabolic energy model "
+            "should be used (default is false).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(smoothing_type, std::string,
             "An optional flag that allows the user to explicitly specify "
-            "whether a smooth approximation, using Huber loss functions, of "
-            "the metabolic energy model should be used (default is false).");
+            "what type of smoothing to use (tanh or huber; default is tanh).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(velocity_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the conditions "
@@ -193,33 +192,19 @@ public:
             "dependent shortening proportionality constant, a tanh "
             "approximation is used even when using the Huber loss smoothing "
             "approach. The smoothness of the transition of that tanh function "
-            "is determined by the tanh_velocity_smoothing parameter. With the "
-            "tanh (Huber loss) function, the larger the steeper (smoother) "
-            "the transition but (and) the worse (better) for optimization "
-            "(default is 10).");
-     OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_velocity_smoothing, double,
-            "The parameter that determines the smoothness of the transition "
-            "of the tanh used to smooth the condition related to contraction "
-            "type (concentric or eccentric) when computing the shortening "
-            "heat rate while using the force dependent shortening "
-            "proportionality constant. In such case, a tanh approximation is "
-            "used even when using the Huber loss smoothing approach. For the "
-            "other conditions related to contraction type, the smoothness is "
-            "determined by the velocity_smoothing parameter. The larger the "
-            "steeper the transition but the worse for optimization "
+            "is determined by the tanh_velocity_smoothing parameter. The "
+            "larger the steeper the transition but the worse for optimization "
             "(default is 10).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(power_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the condition "
-            "enforcing non-negative total power. With the tanh (Huber loss) "
-            "function, the larger the steeper (smoother) the transition but "
-            "(and) the worse (better) for optimization (default is 10).");
+            "enforcing non-negative total power. The larger the steeper the "
+            "transition but the worse for optimization (default is 10).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(heat_rate_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the condition "
             "enforcing total heat rate larger than 1 (W/kg) for a give muscle "
-            ". With the tanh (Huber loss) function, the larger the steeper "
-            "(smoother) the transition but (and) the worse (better) for "
+            ". The larger the steeper the transition but the worse for "
             "optimization (default is 10).");
     OpenSim_DECLARE_LIST_PROPERTY(
             muscle_parameters, Bhargava2004Metabolics_MuscleParameters,
@@ -287,11 +272,9 @@ private:
     using ConditionalFunction =
             double(const double&, const double&, const double&, const double&,
                     const int&);
-    using SmoothConditionalFunction =
-        double(const double&, const double&, const double&, const double&);
     PiecewiseLinearFunction m_fiberLengthDepCurve;
     mutable std::function<ConditionalFunction> m_conditional;
-    mutable std::function<SmoothConditionalFunction> m_tanh_conditional;
+    mutable std::function<ConditionalFunction> m_tanh_conditional;
 };
 
 } // namespace OpenSim

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -197,6 +197,12 @@ public:
             "rate larger than 1 (W/kg) for a give muscle. The larger the "
             "steeper the transition but the worse for optimization (default "
             "is 10).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_huber_loss, bool,
+            "TODO (default is false).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_delta, double,
+            "TODO (default is 1).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_direction, int,
+            "TODO (default is 1).");
 
     OpenSim_DECLARE_LIST_PROPERTY(
             muscle_parameters, Bhargava2004Metabolics_MuscleParameters,
@@ -262,7 +268,8 @@ private:
             SimTK::Vector& mechanicalWorkRatesForMuscles) const;
     mutable std::unordered_map<std::string, int> m_muscleIndices;
     using ConditionalFunction =
-            double(const double&, const double&, const double&, const double&);
+            double(const double&, const double&, const double&, const double&,
+                    const double&, const int&);
     PiecewiseLinearFunction m_fiberLengthDepCurve;
     mutable std::function<ConditionalFunction> m_conditional;
 };

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -187,14 +187,12 @@ public:
     OpenSim_DECLARE_OPTIONAL_PROPERTY(velocity_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the conditions "
-            "related to contraction type (concentric or eccentric). When "
-            "computing the shortening heat rate while using the force "
+            "related to contraction type (concentric or eccentric). Note that "
+            "when computing the shortening heat rate while using the force "
             "dependent shortening proportionality constant, a tanh "
             "approximation is used even when using the Huber loss smoothing "
-            "approach. The smoothness of the transition of that tanh function "
-            "is determined by the tanh_velocity_smoothing parameter. The "
-            "larger the steeper the transition but the worse for optimization "
-            "(default is 10).");
+            "approach. The larger the steeper the transition but the worse "
+            "for optimization (default is 10).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(power_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the condition "

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -179,33 +179,45 @@ public:
             "positive (default is true).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(use_tanh_smoothing, bool,
             "An optional flag that allows the user to explicitly specify "
-            "whether a smooth approximation of the metabolic energy model "
-            "should be used (default is false).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_velocity_smoothing, double,
-            "The parameter that determines the smoothness of the transition "
-            "of the tanh used to smooth the conditions related to contraction "
-            "type (concentric or eccentric). The larger the steeper the "
-            "transition but the worse for optimization (default is 10).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_power_smoothing, double,
-            "The parameter that determines the smoothness of the transition "
-            "of the tanh used to smooth the condition enforcing non-negative "
-            "total power. The larger the steeper the transition but the worse "
-            "for optimization (default is 10).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_heat_rate_smoothing, double,
-            "The parameter that determines the smoothness of the transition "
-            "of the tanh used to smooth the condition enforcing total heat "
-            "rate larger than 1 (W/kg) for a give muscle. The larger the "
-            "steeper the transition but the worse for optimization (default "
-            "is 10).");
+            "whether a smooth approximation, using tanh functions, of the "
+            "metabolic energy model should be used (default is false).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(use_huber_loss_smoothing, bool,
-            "TODO (default is false).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_velocity_smoothing, double,
-        "TODO (default is 5).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_power_smoothing, double,
-        "TODO (default is 5).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_heat_rate_smoothing, double,
-        "TODO (default is 5).");
-
+            "An optional flag that allows the user to explicitly specify "
+            "whether a smooth approximation, using Huber loss functions, of "
+            "the metabolic energy model should be used (default is false).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(velocity_smoothing, double,
+            "The parameter that determines the smoothness of the transition "
+            "of the tanh or Huber loss function used to smooth the conditions "
+            "related to contraction type (concentric or eccentric). When "
+            "computing the shortening heat rate while using the force "
+            "dependent shortening proportionality constant, a tanh "
+            "approximation is used even when using the Huber loss smoothing "
+            "approach. The smoothness of the transition of that tanh function "
+            "is determined by the tanh_velocity_smoothing parameter. The "
+            "larger the steeper the transition but the worse for optimization "
+            "(default is 10).");
+     OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_velocity_smoothing, double,
+            "The parameter that determines the smoothness of the transition "
+            "of the tanh used to smooth the condition related to contraction "
+            "type (concentric or eccentric) when computing the shortening "
+            "heat rate while using the force dependent shortening "
+            "proportionality constant. In such case, a tanh approximation is "
+            "used even when using the Huber loss smoothing approach. For the "
+            "other conditions related to contraction type, the smoothness is "
+            "determined by the velocity_smoothing parameter. The larger the "
+            "steeper the transition but the worse for optimization "
+            "(default is 10)");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(power_smoothing, double,
+            "The parameter that determines the smoothness of the transition "
+            "of the tanh or Huber loss function used to smooth the condition "
+            "enforcing non-negative total power. The larger the steeper the "
+            "transition but the worse for optimization (default is 10).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(heat_rate_smoothing, double,
+            "The parameter that determines the smoothness of the transition "
+            "of the tanh or Huber loss function used to smooth the condition "
+            "enforcing total heat rate larger than 1 (W/kg) for a give muscle "
+            ". The larger the steeper the transition but the worse for "
+            "optimization (default is 10).");
     OpenSim_DECLARE_LIST_PROPERTY(
             muscle_parameters, Bhargava2004Metabolics_MuscleParameters,
             "Metabolic parameters for each muscle.");

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -5,8 +5,8 @@
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *
- * Author(s): Antoine Falisse                                                 *
- * Contributors: Tim Dorn, Thomas Uchida, Christopher Dembia                  *
+ * Author(s): Antoine Falisse, Christopher Dembia, Nick Bianco                *
+ * Contributors: Tim Dorn, Thomas Uchida                                      *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -177,28 +177,34 @@ public:
     OpenSim_DECLARE_PROPERTY(forbid_negative_total_power, bool,
             "Specify whether the total power for each muscle must remain  "
             "positive (default is true).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_smoothing, bool,
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_tanh_smoothing, bool,
             "An optional flag that allows the user to explicitly specify "
             "whether a smooth approximation of the metabolic energy model "
             "should be used (default is false).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(velocity_smoothing, double,
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_velocity_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh used to smooth the conditions related to contraction "
             "type (concentric or eccentric). The larger the steeper the "
             "transition but the worse for optimization (default is 10).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(power_smoothing, double,
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_power_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh used to smooth the condition enforcing non-negative "
             "total power. The larger the steeper the transition but the worse "
             "for optimization (default is 10).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(heat_rate_smoothing, double,
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(tanh_heat_rate_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh used to smooth the condition enforcing total heat "
             "rate larger than 1 (W/kg) for a give muscle. The larger the "
             "steeper the transition but the worse for optimization (default "
             "is 10).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_huber_loss, bool,
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(use_huber_loss_smoothing, bool,
             "TODO (default is false).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_velocity_smoothing, double,
+        "TODO (default is 5).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_power_smoothing, double,
+        "TODO (default is 5).");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_heat_rate_smoothing, double,
+        "TODO (default is 5).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_delta, double,
             "TODO (default is 1).");
 
@@ -268,8 +274,11 @@ private:
     using ConditionalFunction =
             double(const double&, const double&, const double&, const double&,
                     const double&, const int&);
+    using SmoothConditionalFunction =
+        double(const double&, const double&, const double&, const double&);
     PiecewiseLinearFunction m_fiberLengthDepCurve;
     mutable std::function<ConditionalFunction> m_conditional;
+    mutable std::function<SmoothConditionalFunction> m_tanh_conditional;
 };
 
 } // namespace OpenSim

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -205,8 +205,6 @@ public:
         "TODO (default is 5).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_heat_rate_smoothing, double,
         "TODO (default is 5).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_delta, double,
-            "TODO (default is 1).");
 
     OpenSim_DECLARE_LIST_PROPERTY(
             muscle_parameters, Bhargava2004Metabolics_MuscleParameters,
@@ -273,7 +271,7 @@ private:
     mutable std::unordered_map<std::string, int> m_muscleIndices;
     using ConditionalFunction =
             double(const double&, const double&, const double&, const double&,
-                    const double&, const int&);
+                    const int&);
     using SmoothConditionalFunction =
         double(const double&, const double&, const double&, const double&);
     PiecewiseLinearFunction m_fiberLengthDepCurve;

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -183,7 +183,8 @@ public:
             "should be used (default is false).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(smoothing_type, std::string,
             "An optional flag that allows the user to explicitly specify "
-            "what type of smoothing to use (tanh or huber; default is tanh).");
+            "what type of smoothing to use ('tanh' or 'huber'; default is "
+            "'tanh').");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(velocity_smoothing, double,
             "The parameter that determines the smoothness of the transition "
             "of the tanh or Huber loss function used to smooth the conditions "

--- a/Moco/Moco/Components/Bhargava2004Metabolics.h
+++ b/Moco/Moco/Components/Bhargava2004Metabolics.h
@@ -201,8 +201,6 @@ public:
             "TODO (default is false).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_delta, double,
             "TODO (default is 1).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(huber_loss_direction, int,
-            "TODO (default is 1).");
 
     OpenSim_DECLARE_LIST_PROPERTY(
             muscle_parameters, Bhargava2004Metabolics_MuscleParameters,

--- a/Moco/Tests/testMocoMetabolics.cpp
+++ b/Moco/Tests/testMocoMetabolics.cpp
@@ -51,19 +51,19 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     model.addComponent(metabolicsPtr_nonSmooth);
     auto& metabolics_nonSmooth =
             model.getComponent<Bhargava2004Metabolics>("metabolics_nonSmooth");
-    // Add non-smooth metabolics with force_dependent_shortening_prop_constant.
-    auto metabolicsPtr_forceDep_nonSmooth = new Bhargava2004Metabolics();
-    metabolicsPtr_forceDep_nonSmooth->setName("metabolics_forceDep_nonSmooth");
-    metabolicsPtr_forceDep_nonSmooth->set_use_smoothing(false);
-    metabolicsPtr_forceDep_nonSmooth->
-            set_use_force_dependent_shortening_prop_constant(true);
-    metabolicsPtr_forceDep_nonSmooth->
-            set_include_negative_mechanical_work(false);
-    metabolicsPtr_forceDep_nonSmooth->addMuscle("muscle",  muscle);
-    model.addComponent(metabolicsPtr_forceDep_nonSmooth);
-    auto& metabolics_forceDep_nonSmooth =
-            model.getComponent<Bhargava2004Metabolics>(
-                    "metabolics_forceDep_nonSmooth");
+    //// Add non-smooth metabolics with force_dependent_shortening_prop_constant.
+    //auto metabolicsPtr_forceDep_nonSmooth = new Bhargava2004Metabolics();
+    //metabolicsPtr_forceDep_nonSmooth->setName("metabolics_forceDep_nonSmooth");
+    //metabolicsPtr_forceDep_nonSmooth->set_use_smoothing(false);
+    //metabolicsPtr_forceDep_nonSmooth->
+    //        set_use_force_dependent_shortening_prop_constant(true);
+    //metabolicsPtr_forceDep_nonSmooth->
+    //        set_include_negative_mechanical_work(false);
+    //metabolicsPtr_forceDep_nonSmooth->addMuscle("muscle",  muscle);
+    //model.addComponent(metabolicsPtr_forceDep_nonSmooth);
+    //auto& metabolics_forceDep_nonSmooth =
+    //        model.getComponent<Bhargava2004Metabolics>(
+    //                "metabolics_forceDep_nonSmooth");
     // Add non-smooth metabolics with negative mechanical work.
     auto metabolicsPtr_negativeWork_nonSmooth = new Bhargava2004Metabolics();
     metabolicsPtr_negativeWork_nonSmooth->setName(
@@ -78,7 +78,7 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     // Add smooth metabolics
     auto metabolicsPtr_smooth = new Bhargava2004Metabolics();
     metabolicsPtr_smooth->setName("metabolics_smooth");
-    metabolicsPtr_smooth->set_use_smoothing(true);
+    metabolicsPtr_smooth->set_use_huber_loss(true);
     // We set a high value for the velocity and heat rate smoothing parameters
     // so that the tanh transitions are very steep and the smooth models best
     // approximate the non-smooth models. In pratice we use lower values
@@ -90,27 +90,30 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     model.addComponent(metabolicsPtr_smooth);
     auto& metabolics_smooth =
             model.getComponent<Bhargava2004Metabolics>("metabolics_smooth");
-    // Add smooth metabolics with force_dependent_shortening_prop_constant.
-    auto metabolicsPtr_forceDep_smooth = new Bhargava2004Metabolics();
-    metabolicsPtr_forceDep_smooth->setName("metabolics_forceDep_smooth");
-    metabolicsPtr_forceDep_smooth->set_use_smoothing(true);
-    // We set a high value for the velocity smoothing parameter so that
-    // the tanh transition is very steep and the smooth model best approximates
-    // the non-smooth model. In pratice we use a lower value (default is 10).
-    metabolicsPtr_forceDep_smooth->
-            set_use_force_dependent_shortening_prop_constant(true);
-    metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
-    metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
-    metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
-    model.addComponent(metabolicsPtr_forceDep_smooth);
-    auto& metabolics_forceDep_smooth =
-            model.getComponent<Bhargava2004Metabolics>(
-                    "metabolics_forceDep_smooth");
+    //// Add smooth metabolics with force_dependent_shortening_prop_constant.
+    //auto metabolicsPtr_forceDep_smooth = new Bhargava2004Metabolics();
+    //metabolicsPtr_forceDep_smooth->setName("metabolics_forceDep_smooth");
+    //metabolicsPtr_forceDep_smooth->set_use_huber_loss(true);
+    //// We set a high value for the velocity smoothing parameter so that
+    //// the tanh transition is very steep and the smooth model best approximates
+    //// the non-smooth model. In pratice we use a lower value (default is 10).
+    //metabolicsPtr_forceDep_smooth->
+    //        set_use_force_dependent_shortening_prop_constant(true);
+    //metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
+    //metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
+    //metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
+    //model.addComponent(metabolicsPtr_forceDep_smooth);
+    //auto& metabolics_forceDep_smooth =
+    //        model.getComponent<Bhargava2004Metabolics>(
+    //                "metabolics_forceDep_smooth");
     // Add smooth metabolics with negative mechanical work.
     auto metabolicsPtr_negativeWork_smooth = new Bhargava2004Metabolics();
     metabolicsPtr_negativeWork_smooth->setName(
             "metabolics_negativeWork_smooth");
-    metabolicsPtr_negativeWork_smooth->set_use_smoothing(false);
+    metabolicsPtr_negativeWork_smooth->set_use_huber_loss(true);
+    metabolicsPtr_negativeWork_smooth->set_velocity_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_power_smoothing(1e6);
     metabolicsPtr_negativeWork_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_negativeWork_smooth);
     auto& metabolics_negativeWork_smooth =
@@ -147,30 +150,30 @@ TEST_CASE("Bhargava2004Metabolics basics") {
                 // force_dependent_shortening_prop_constant.
                 CHECK(metabolics_nonSmooth.getTotalShorteningRate(state) ==
                         Approx(metabolics_smooth.
-                                getTotalShorteningRate(state)).margin(1e-6));
+                                getTotalShorteningRate(state)).margin(1e-4));
                 CHECK(metabolics_nonSmooth.getTotalMechanicalWorkRate(state) ==
                         Approx(metabolics_smooth.
                                 getTotalMechanicalWorkRate(state)).
-                                        margin(1e-6));
+                                        margin(1e-4));
                 CHECK(metabolics_nonSmooth.getTotalMetabolicRate(state) ==
                         Approx(metabolics_smooth.getTotalMetabolicRate(state)).
-                                margin(1e-6));
-                // Metabolics using force_dependent_shortening_prop_constant.
-                CHECK(metabolics_forceDep_nonSmooth.
-                        getTotalShorteningRate(state) == Approx(
-                                metabolics_forceDep_smooth.
-                                        getTotalShorteningRate(state)).
-                                                margin(1e-6));
-                CHECK(metabolics_forceDep_nonSmooth.
-                        getTotalMechanicalWorkRate(state) == Approx(
-                                metabolics_forceDep_smooth.
-                                        getTotalMechanicalWorkRate(state)).
-                                                margin(1e-6));
-                CHECK(metabolics_forceDep_nonSmooth.
-                        getTotalMetabolicRate(state) == Approx(
-                                metabolics_forceDep_smooth.
-                                        getTotalMetabolicRate(state)).
-                                                margin(1e-6));
+                                margin(1e-4));
+                //// Metabolics using force_dependent_shortening_prop_constant.
+                //CHECK(metabolics_forceDep_nonSmooth.
+                //        getTotalShorteningRate(state) == Approx(
+                //                metabolics_forceDep_smooth.
+                //                        getTotalShorteningRate(state)).
+                //                                margin(1e-4));
+                //CHECK(metabolics_forceDep_nonSmooth.
+                //        getTotalMechanicalWorkRate(state) == Approx(
+                //                metabolics_forceDep_smooth.
+                //                        getTotalMechanicalWorkRate(state)).
+                //                                margin(1e-4));
+                //CHECK(metabolics_forceDep_nonSmooth.
+                //        getTotalMetabolicRate(state) == Approx(
+                //                metabolics_forceDep_smooth.
+                //                        getTotalMetabolicRate(state)).
+                //                                margin(1e-4));
             }
         }
 
@@ -188,10 +191,10 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             model.realizeDynamics(state);
             // Non-smooth metabolics model.
             CHECK(metabolics_nonSmooth.getTotalMechanicalWorkRate(state) ==
-                    Approx(0).margin(1e-6));
+                    Approx(0).margin(1e-4));
             // Smooth metabolics model.
             CHECK(metabolics_smooth.getTotalMechanicalWorkRate(state) ==
-                    Approx(0).margin(1e-6));
+                    Approx(0).margin(1e-4));
         }
 
         SECTION("activationHeatRate=0 and maintenanceHeatRate=0 if "
@@ -297,7 +300,7 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             model.setControls(state, controls);
 
             model.realizeDynamics(state);
-            double mechanicalWorkRate = 0;
+            double mechanicalWorkRate = 0.0;
             // Non-smooth metabolics model.
             CHECK(mechanicalWorkRate ==
                     metabolics_nonSmooth.getTotalMechanicalWorkRate(state));
@@ -414,7 +417,7 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             CHECK(totalMetabolicRate_nonSmooth - basalRate_nonSmooth
                     - mechanicalWorkRate_nonSmooth - metabolics_nonSmooth.
                             get_muscle_parameters(0).getMuscleMass() ==
-                                    Approx(0.0).margin(1e-6));
+                                    Approx(0.0).margin(1e-4));
             // Smooth metabolics model.
             double activationHeatRate_smooth =
                     metabolics_smooth.getTotalActivationRate(state);
@@ -445,7 +448,7 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             CHECK(totalMetabolicRate_smooth - basalRate_smooth
                     - mechanicalWorkRate_smooth - metabolics_smooth.
                             get_muscle_parameters(0).getMuscleMass() ==
-                                    Approx(0.0).margin(1e-6));
+                                    Approx(0.0).margin(1e-4));
         }
 
     }

--- a/Moco/Tests/testMocoMetabolics.cpp
+++ b/Moco/Tests/testMocoMetabolics.cpp
@@ -45,7 +45,6 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     // Add non-smooth metabolics
     auto metabolicsPtr_nonSmooth = new Bhargava2004Metabolics();
     metabolicsPtr_nonSmooth->setName("metabolics_nonSmooth");
-    metabolicsPtr_nonSmooth->set_use_smoothing(false);
     metabolicsPtr_nonSmooth->set_include_negative_mechanical_work(false);
     metabolicsPtr_nonSmooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_nonSmooth);
@@ -54,7 +53,6 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     // Add non-smooth metabolics with force_dependent_shortening_prop_constant.
     auto metabolicsPtr_forceDep_nonSmooth = new Bhargava2004Metabolics();
     metabolicsPtr_forceDep_nonSmooth->setName("metabolics_forceDep_nonSmooth");
-    metabolicsPtr_forceDep_nonSmooth->set_use_smoothing(false);
     metabolicsPtr_forceDep_nonSmooth->
             set_use_force_dependent_shortening_prop_constant(true);
     metabolicsPtr_forceDep_nonSmooth->
@@ -68,7 +66,6 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     auto metabolicsPtr_negativeWork_nonSmooth = new Bhargava2004Metabolics();
     metabolicsPtr_negativeWork_nonSmooth->setName(
             "metabolics_negativeWork_nonSmooth");
-    metabolicsPtr_negativeWork_nonSmooth->set_use_smoothing(false);
     metabolicsPtr_negativeWork_nonSmooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_negativeWork_nonSmooth);
     auto& metabolics_negativeWork_nonSmooth =
@@ -78,13 +75,13 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     // Add smooth metabolics
     auto metabolicsPtr_smooth = new Bhargava2004Metabolics();
     metabolicsPtr_smooth->setName("metabolics_smooth");
-    metabolicsPtr_smooth->set_use_huber_loss(true);
+    metabolicsPtr_smooth->set_use_huber_loss_smoothing(true);
     // We set a high value for the velocity and heat rate smoothing parameters
     // so that the tanh transitions are very steep and the smooth models best
     // approximate the non-smooth models. In pratice we use lower values
     // (default is 10).
-    metabolicsPtr_smooth->set_velocity_smoothing(1e6);
-    metabolicsPtr_smooth->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_smooth->set_huber_loss_velocity_smoothing(1e6);
+    metabolicsPtr_smooth->set_huber_loss_heat_rate_smoothing(1e6);
     metabolicsPtr_smooth->set_include_negative_mechanical_work(false);
     metabolicsPtr_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_smooth);
@@ -93,13 +90,14 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     // Add smooth metabolics with force_dependent_shortening_prop_constant.
     auto metabolicsPtr_forceDep_smooth = new Bhargava2004Metabolics();
     metabolicsPtr_forceDep_smooth->setName("metabolics_forceDep_smooth");
-    metabolicsPtr_forceDep_smooth->set_use_huber_loss(true);
+    metabolicsPtr_forceDep_smooth->set_use_huber_loss_smoothing(true);
     // We set a high value for the velocity smoothing parameter so that
     // the tanh transition is very steep and the smooth model best approximates
     // the non-smooth model. In pratice we use a lower value (default is 10).
     metabolicsPtr_forceDep_smooth->
             set_use_force_dependent_shortening_prop_constant(true);
-    metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
+    metabolicsPtr_forceDep_smooth->set_tanh_velocity_smoothing(1e6);
+    metabolicsPtr_forceDep_smooth->set_huber_loss_velocity_smoothing(1e6);
     metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
     metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_forceDep_smooth);
@@ -110,10 +108,10 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     auto metabolicsPtr_negativeWork_smooth = new Bhargava2004Metabolics();
     metabolicsPtr_negativeWork_smooth->setName(
             "metabolics_negativeWork_smooth");
-    metabolicsPtr_negativeWork_smooth->set_use_huber_loss(true);
-    metabolicsPtr_negativeWork_smooth->set_velocity_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->set_heat_rate_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->set_power_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_use_huber_loss_smoothing(true);
+    metabolicsPtr_negativeWork_smooth->set_huber_loss_velocity_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_huber_loss_heat_rate_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_huber_loss_power_smoothing(1e6);
     metabolicsPtr_negativeWork_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_negativeWork_smooth);
     auto& metabolics_negativeWork_smooth =

--- a/Moco/Tests/testMocoMetabolics.cpp
+++ b/Moco/Tests/testMocoMetabolics.cpp
@@ -80,8 +80,8 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     // so that the tanh transitions are very steep and the smooth models best
     // approximate the non-smooth models. In pratice we use lower values
     // (default is 10).
-    metabolicsPtr_smooth->set_huber_loss_velocity_smoothing(1e6);
-    metabolicsPtr_smooth->set_huber_loss_heat_rate_smoothing(1e6);
+    metabolicsPtr_smooth->set_velocity_smoothing(1e6);
+    metabolicsPtr_smooth->set_heat_rate_smoothing(1e6);
     metabolicsPtr_smooth->set_include_negative_mechanical_work(false);
     metabolicsPtr_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_smooth);
@@ -97,7 +97,7 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     metabolicsPtr_forceDep_smooth->
             set_use_force_dependent_shortening_prop_constant(true);
     metabolicsPtr_forceDep_smooth->set_tanh_velocity_smoothing(1e6);
-    metabolicsPtr_forceDep_smooth->set_huber_loss_velocity_smoothing(1e6);
+    metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
     metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
     metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_forceDep_smooth);
@@ -109,9 +109,9 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     metabolicsPtr_negativeWork_smooth->setName(
             "metabolics_negativeWork_smooth");
     metabolicsPtr_negativeWork_smooth->set_use_huber_loss_smoothing(true);
-    metabolicsPtr_negativeWork_smooth->set_huber_loss_velocity_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->set_huber_loss_heat_rate_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->set_huber_loss_power_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_velocity_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth->set_power_smoothing(1e6);
     metabolicsPtr_negativeWork_smooth->addMuscle("muscle",  muscle);
     model.addComponent(metabolicsPtr_negativeWork_smooth);
     auto& metabolics_negativeWork_smooth =

--- a/Moco/Tests/testMocoMetabolics.cpp
+++ b/Moco/Tests/testMocoMetabolics.cpp
@@ -51,19 +51,19 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     model.addComponent(metabolicsPtr_nonSmooth);
     auto& metabolics_nonSmooth =
             model.getComponent<Bhargava2004Metabolics>("metabolics_nonSmooth");
-    //// Add non-smooth metabolics with force_dependent_shortening_prop_constant.
-    //auto metabolicsPtr_forceDep_nonSmooth = new Bhargava2004Metabolics();
-    //metabolicsPtr_forceDep_nonSmooth->setName("metabolics_forceDep_nonSmooth");
-    //metabolicsPtr_forceDep_nonSmooth->set_use_smoothing(false);
-    //metabolicsPtr_forceDep_nonSmooth->
-    //        set_use_force_dependent_shortening_prop_constant(true);
-    //metabolicsPtr_forceDep_nonSmooth->
-    //        set_include_negative_mechanical_work(false);
-    //metabolicsPtr_forceDep_nonSmooth->addMuscle("muscle",  muscle);
-    //model.addComponent(metabolicsPtr_forceDep_nonSmooth);
-    //auto& metabolics_forceDep_nonSmooth =
-    //        model.getComponent<Bhargava2004Metabolics>(
-    //                "metabolics_forceDep_nonSmooth");
+    // Add non-smooth metabolics with force_dependent_shortening_prop_constant.
+    auto metabolicsPtr_forceDep_nonSmooth = new Bhargava2004Metabolics();
+    metabolicsPtr_forceDep_nonSmooth->setName("metabolics_forceDep_nonSmooth");
+    metabolicsPtr_forceDep_nonSmooth->set_use_smoothing(false);
+    metabolicsPtr_forceDep_nonSmooth->
+            set_use_force_dependent_shortening_prop_constant(true);
+    metabolicsPtr_forceDep_nonSmooth->
+            set_include_negative_mechanical_work(false);
+    metabolicsPtr_forceDep_nonSmooth->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_forceDep_nonSmooth);
+    auto& metabolics_forceDep_nonSmooth =
+            model.getComponent<Bhargava2004Metabolics>(
+                    "metabolics_forceDep_nonSmooth");
     // Add non-smooth metabolics with negative mechanical work.
     auto metabolicsPtr_negativeWork_nonSmooth = new Bhargava2004Metabolics();
     metabolicsPtr_negativeWork_nonSmooth->setName(
@@ -90,22 +90,22 @@ TEST_CASE("Bhargava2004Metabolics basics") {
     model.addComponent(metabolicsPtr_smooth);
     auto& metabolics_smooth =
             model.getComponent<Bhargava2004Metabolics>("metabolics_smooth");
-    //// Add smooth metabolics with force_dependent_shortening_prop_constant.
-    //auto metabolicsPtr_forceDep_smooth = new Bhargava2004Metabolics();
-    //metabolicsPtr_forceDep_smooth->setName("metabolics_forceDep_smooth");
-    //metabolicsPtr_forceDep_smooth->set_use_huber_loss(true);
-    //// We set a high value for the velocity smoothing parameter so that
-    //// the tanh transition is very steep and the smooth model best approximates
-    //// the non-smooth model. In pratice we use a lower value (default is 10).
-    //metabolicsPtr_forceDep_smooth->
-    //        set_use_force_dependent_shortening_prop_constant(true);
-    //metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
-    //metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
-    //metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
-    //model.addComponent(metabolicsPtr_forceDep_smooth);
-    //auto& metabolics_forceDep_smooth =
-    //        model.getComponent<Bhargava2004Metabolics>(
-    //                "metabolics_forceDep_smooth");
+    // Add smooth metabolics with force_dependent_shortening_prop_constant.
+    auto metabolicsPtr_forceDep_smooth = new Bhargava2004Metabolics();
+    metabolicsPtr_forceDep_smooth->setName("metabolics_forceDep_smooth");
+    metabolicsPtr_forceDep_smooth->set_use_huber_loss(true);
+    // We set a high value for the velocity smoothing parameter so that
+    // the tanh transition is very steep and the smooth model best approximates
+    // the non-smooth model. In pratice we use a lower value (default is 10).
+    metabolicsPtr_forceDep_smooth->
+            set_use_force_dependent_shortening_prop_constant(true);
+    metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
+    metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
+    metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_forceDep_smooth);
+    auto& metabolics_forceDep_smooth =
+            model.getComponent<Bhargava2004Metabolics>(
+                    "metabolics_forceDep_smooth");
     // Add smooth metabolics with negative mechanical work.
     auto metabolicsPtr_negativeWork_smooth = new Bhargava2004Metabolics();
     metabolicsPtr_negativeWork_smooth->setName(
@@ -158,22 +158,22 @@ TEST_CASE("Bhargava2004Metabolics basics") {
                 CHECK(metabolics_nonSmooth.getTotalMetabolicRate(state) ==
                         Approx(metabolics_smooth.getTotalMetabolicRate(state)).
                                 margin(1e-4));
-                //// Metabolics using force_dependent_shortening_prop_constant.
-                //CHECK(metabolics_forceDep_nonSmooth.
-                //        getTotalShorteningRate(state) == Approx(
-                //                metabolics_forceDep_smooth.
-                //                        getTotalShorteningRate(state)).
-                //                                margin(1e-4));
-                //CHECK(metabolics_forceDep_nonSmooth.
-                //        getTotalMechanicalWorkRate(state) == Approx(
-                //                metabolics_forceDep_smooth.
-                //                        getTotalMechanicalWorkRate(state)).
-                //                                margin(1e-4));
-                //CHECK(metabolics_forceDep_nonSmooth.
-                //        getTotalMetabolicRate(state) == Approx(
-                //                metabolics_forceDep_smooth.
-                //                        getTotalMetabolicRate(state)).
-                //                                margin(1e-4));
+                // Metabolics using force_dependent_shortening_prop_constant.
+                CHECK(metabolics_forceDep_nonSmooth.
+                        getTotalShorteningRate(state) == Approx(
+                                metabolics_forceDep_smooth.
+                                        getTotalShorteningRate(state)).
+                                                margin(1e-4));
+                CHECK(metabolics_forceDep_nonSmooth.
+                        getTotalMechanicalWorkRate(state) == Approx(
+                                metabolics_forceDep_smooth.
+                                        getTotalMechanicalWorkRate(state)).
+                                                margin(1e-4));
+                CHECK(metabolics_forceDep_nonSmooth.
+                        getTotalMetabolicRate(state) == Approx(
+                                metabolics_forceDep_smooth.
+                                        getTotalMetabolicRate(state)).
+                                                margin(1e-4));
             }
         }
 

--- a/Moco/Tests/testMocoMetabolics.cpp
+++ b/Moco/Tests/testMocoMetabolics.cpp
@@ -72,51 +72,109 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             model.getComponent<Bhargava2004Metabolics>(
                     "metabolics_negativeWork_nonSmooth");
 
-    // Add smooth metabolics
-    auto metabolicsPtr_smooth = new Bhargava2004Metabolics();
-    metabolicsPtr_smooth->setName("metabolics_smooth");
-    metabolicsPtr_smooth->set_use_huber_loss_smoothing(true);
+    // Add smooth (using tanh function) metabolics
+    auto metabolicsPtr_smooth_tanh = new Bhargava2004Metabolics();
+    metabolicsPtr_smooth_tanh->setName("metabolics_smooth_tanh");
+    metabolicsPtr_smooth_tanh->set_use_smoothing(true);
     // We set a high value for the velocity and heat rate smoothing parameters
     // so that the tanh transitions are very steep and the smooth models best
     // approximate the non-smooth models. In pratice we use lower values
     // (default is 10).
-    metabolicsPtr_smooth->set_velocity_smoothing(1e6);
-    metabolicsPtr_smooth->set_heat_rate_smoothing(1e6);
-    metabolicsPtr_smooth->set_include_negative_mechanical_work(false);
-    metabolicsPtr_smooth->addMuscle("muscle",  muscle);
-    model.addComponent(metabolicsPtr_smooth);
-    auto& metabolics_smooth =
-            model.getComponent<Bhargava2004Metabolics>("metabolics_smooth");
-    // Add smooth metabolics with force_dependent_shortening_prop_constant.
-    auto metabolicsPtr_forceDep_smooth = new Bhargava2004Metabolics();
-    metabolicsPtr_forceDep_smooth->setName("metabolics_forceDep_smooth");
-    metabolicsPtr_forceDep_smooth->set_use_huber_loss_smoothing(true);
+    metabolicsPtr_smooth_tanh->set_velocity_smoothing(1e6);
+    metabolicsPtr_smooth_tanh->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_smooth_tanh->set_include_negative_mechanical_work(false);
+    metabolicsPtr_smooth_tanh->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_smooth_tanh);
+    auto& metabolics_smooth_tanh =
+            model.getComponent<Bhargava2004Metabolics>(
+                    "metabolics_smooth_tanh");
+    // Add smooth (using tanh function) metabolics with
+    // force_dependent_shortening_prop_constant.
+    auto metabolicsPtr_forceDep_smooth_tanh = new Bhargava2004Metabolics();
+    metabolicsPtr_forceDep_smooth_tanh->setName(
+            "metabolics_forceDep_smooth_tanh");
+    metabolicsPtr_forceDep_smooth_tanh->set_use_smoothing(true);
     // We set a high value for the velocity smoothing parameter so that
     // the tanh transition is very steep and the smooth model best approximates
     // the non-smooth model. In pratice we use a lower value (default is 10).
-    metabolicsPtr_forceDep_smooth->
+    metabolicsPtr_forceDep_smooth_tanh->
             set_use_force_dependent_shortening_prop_constant(true);
-    metabolicsPtr_forceDep_smooth->set_tanh_velocity_smoothing(1e6);
-    metabolicsPtr_forceDep_smooth->set_velocity_smoothing(1e6);
-    metabolicsPtr_forceDep_smooth->set_include_negative_mechanical_work(false);
-    metabolicsPtr_forceDep_smooth->addMuscle("muscle",  muscle);
-    model.addComponent(metabolicsPtr_forceDep_smooth);
-    auto& metabolics_forceDep_smooth =
+    metabolicsPtr_forceDep_smooth_tanh->set_velocity_smoothing(1e6);
+    metabolicsPtr_forceDep_smooth_tanh->set_include_negative_mechanical_work(
+            false);
+    metabolicsPtr_forceDep_smooth_tanh->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_forceDep_smooth_tanh);
+    auto& metabolics_forceDep_smooth_tanh =
             model.getComponent<Bhargava2004Metabolics>(
-                    "metabolics_forceDep_smooth");
-    // Add smooth metabolics with negative mechanical work.
-    auto metabolicsPtr_negativeWork_smooth = new Bhargava2004Metabolics();
-    metabolicsPtr_negativeWork_smooth->setName(
-            "metabolics_negativeWork_smooth");
-    metabolicsPtr_negativeWork_smooth->set_use_huber_loss_smoothing(true);
-    metabolicsPtr_negativeWork_smooth->set_velocity_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->set_heat_rate_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->set_power_smoothing(1e6);
-    metabolicsPtr_negativeWork_smooth->addMuscle("muscle",  muscle);
-    model.addComponent(metabolicsPtr_negativeWork_smooth);
-    auto& metabolics_negativeWork_smooth =
+                    "metabolics_forceDep_smooth_tanh");
+    // Add smooth (using tanh function) metabolics with negative mechanical
+    // work.
+    auto metabolicsPtr_negativeWork_smooth_tanh = new Bhargava2004Metabolics();
+    metabolicsPtr_negativeWork_smooth_tanh->setName(
+            "metabolics_negativeWork_smooth_tanh");
+    metabolicsPtr_negativeWork_smooth_tanh->set_use_smoothing(true);
+    metabolicsPtr_negativeWork_smooth_tanh->set_velocity_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth_tanh->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth_tanh->set_power_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth_tanh->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_negativeWork_smooth_tanh);
+    auto& metabolics_negativeWork_smooth_tanh =
             model.getComponent<Bhargava2004Metabolics>(
-                    "metabolics_negativeWork_smooth");
+                    "metabolics_negativeWork_smooth_tanh");
+    // Add smooth (using Huber loss function) metabolics
+    auto metabolicsPtr_smooth_huber = new Bhargava2004Metabolics();
+    metabolicsPtr_smooth_huber->setName("metabolics_smooth_huber");
+    metabolicsPtr_smooth_huber->set_use_smoothing(true);
+    metabolicsPtr_smooth_huber->set_smoothing_type("huber");
+    // We set a high value for the velocity and heat rate smoothing parameters
+    // so that the Huber loss transitions are very steep and the smooth models
+    // best approximate the non-smooth models. In pratice we use lower values
+    // (default is 10).
+    metabolicsPtr_smooth_huber->set_velocity_smoothing(1e6);
+    metabolicsPtr_smooth_huber->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_smooth_huber->set_include_negative_mechanical_work(false);
+    metabolicsPtr_smooth_huber->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_smooth_huber);
+    auto& metabolics_smooth_huber =
+            model.getComponent<Bhargava2004Metabolics>(
+                    "metabolics_smooth_huber");
+    // Add smooth (using Huber loss function) metabolics with
+    // force_dependent_shortening_prop_constant.
+    auto metabolicsPtr_forceDep_smooth_huber = new Bhargava2004Metabolics();
+    metabolicsPtr_forceDep_smooth_huber->setName(
+            "metabolics_forceDep_smooth_huber");
+    metabolicsPtr_forceDep_smooth_huber->set_use_smoothing(true);
+    metabolicsPtr_forceDep_smooth_huber->set_smoothing_type("huber");
+    // We set a high value for the velocity smoothing parameter so that
+    // the Huber loss transition is very steep and the smooth model best
+    // approximates the non-smooth model. In pratice we use a lower value
+    // (default is 10).
+    metabolicsPtr_forceDep_smooth_huber->
+            set_use_force_dependent_shortening_prop_constant(true);
+    metabolicsPtr_forceDep_smooth_huber->set_velocity_smoothing(1e6);
+    metabolicsPtr_forceDep_smooth_huber->set_include_negative_mechanical_work(
+            false);
+    metabolicsPtr_forceDep_smooth_huber->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_forceDep_smooth_huber);
+    auto& metabolics_forceDep_smooth_huber =
+            model.getComponent<Bhargava2004Metabolics>(
+                    "metabolics_forceDep_smooth_huber");
+    // Add smooth (using Huber loss function) metabolics with negative
+    // mechanical work.
+    auto metabolicsPtr_negativeWork_smooth_huber =
+            new Bhargava2004Metabolics();
+    metabolicsPtr_negativeWork_smooth_huber->setName(
+            "metabolics_negativeWork_smooth_huber");
+    metabolicsPtr_negativeWork_smooth_huber->set_use_smoothing(true);
+    metabolicsPtr_negativeWork_smooth_huber->set_smoothing_type("huber");
+    metabolicsPtr_negativeWork_smooth_huber->set_velocity_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth_huber->set_heat_rate_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth_huber->set_power_smoothing(1e6);
+    metabolicsPtr_negativeWork_smooth_huber->addMuscle("muscle",  muscle);
+    model.addComponent(metabolicsPtr_negativeWork_smooth_huber);
+    auto& metabolics_negativeWork_smooth_huber =
+            model.getComponent<Bhargava2004Metabolics>(
+                    "metabolics_negativeWork_smooth_huber");
     model.finalizeConnections();
 
     SECTION("Verify computed values") {
@@ -147,29 +205,54 @@ TEST_CASE("Bhargava2004Metabolics basics") {
                 // Metabolics not using
                 // force_dependent_shortening_prop_constant.
                 CHECK(metabolics_nonSmooth.getTotalShorteningRate(state) ==
-                        Approx(metabolics_smooth.
+                        Approx(metabolics_smooth_tanh.
+                                getTotalShorteningRate(state)).margin(1e-4));
+                CHECK(metabolics_nonSmooth.getTotalShorteningRate(state) ==
+                        Approx(metabolics_smooth_huber.
                                 getTotalShorteningRate(state)).margin(1e-4));
                 CHECK(metabolics_nonSmooth.getTotalMechanicalWorkRate(state) ==
-                        Approx(metabolics_smooth.
+                        Approx(metabolics_smooth_tanh.
+                                getTotalMechanicalWorkRate(state)).
+                                        margin(1e-4));
+                CHECK(metabolics_nonSmooth.getTotalMechanicalWorkRate(state) ==
+                        Approx(metabolics_smooth_huber.
                                 getTotalMechanicalWorkRate(state)).
                                         margin(1e-4));
                 CHECK(metabolics_nonSmooth.getTotalMetabolicRate(state) ==
-                        Approx(metabolics_smooth.getTotalMetabolicRate(state)).
-                                margin(1e-4));
+                        Approx(metabolics_smooth_tanh.getTotalMetabolicRate(
+                                state)).margin(1e-4));
+                CHECK(metabolics_nonSmooth.getTotalMetabolicRate(state) ==
+                        Approx(metabolics_smooth_huber.getTotalMetabolicRate(
+                                state)).margin(1e-4));
                 // Metabolics using force_dependent_shortening_prop_constant.
                 CHECK(metabolics_forceDep_nonSmooth.
                         getTotalShorteningRate(state) == Approx(
-                                metabolics_forceDep_smooth.
+                                metabolics_forceDep_smooth_tanh.
+                                        getTotalShorteningRate(state)).
+                                                margin(1e-4));
+                CHECK(metabolics_forceDep_nonSmooth.
+                        getTotalShorteningRate(state) == Approx(
+                                metabolics_forceDep_smooth_huber.
                                         getTotalShorteningRate(state)).
                                                 margin(1e-4));
                 CHECK(metabolics_forceDep_nonSmooth.
                         getTotalMechanicalWorkRate(state) == Approx(
-                                metabolics_forceDep_smooth.
+                                metabolics_forceDep_smooth_tanh.
+                                        getTotalMechanicalWorkRate(state)).
+                                                margin(1e-4));
+                CHECK(metabolics_forceDep_nonSmooth.
+                        getTotalMechanicalWorkRate(state) == Approx(
+                                metabolics_forceDep_smooth_huber.
                                         getTotalMechanicalWorkRate(state)).
                                                 margin(1e-4));
                 CHECK(metabolics_forceDep_nonSmooth.
                         getTotalMetabolicRate(state) == Approx(
-                                metabolics_forceDep_smooth.
+                                metabolics_forceDep_smooth_tanh.
+                                        getTotalMetabolicRate(state)).
+                                                margin(1e-4));
+                CHECK(metabolics_forceDep_nonSmooth.
+                        getTotalMetabolicRate(state) == Approx(
+                                metabolics_forceDep_smooth_huber.
                                         getTotalMetabolicRate(state)).
                                                 margin(1e-4));
             }
@@ -190,8 +273,10 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             // Non-smooth metabolics model.
             CHECK(metabolics_nonSmooth.getTotalMechanicalWorkRate(state) ==
                     Approx(0).margin(1e-4));
-            // Smooth metabolics model.
-            CHECK(metabolics_smooth.getTotalMechanicalWorkRate(state) ==
+            // Smooth metabolics models.
+            CHECK(metabolics_smooth_tanh.getTotalMechanicalWorkRate(state) ==
+                    Approx(0).margin(1e-4));
+            CHECK(metabolics_smooth_huber.getTotalMechanicalWorkRate(state) ==
                     Approx(0).margin(1e-4));
         }
 
@@ -214,11 +299,16 @@ TEST_CASE("Bhargava2004Metabolics basics") {
                     Approx(0.0));
             CHECK(metabolics_nonSmooth.getTotalMaintenanceRate(state) ==
                     Approx(0.0));
-            // Smooth metabolics model.
-            CHECK(metabolics_smooth.getTotalActivationRate(state) ==
+            // Smooth metabolics models.
+            CHECK(metabolics_smooth_tanh.getTotalActivationRate(state) ==
                     Approx(0.0));
-            CHECK(metabolics_smooth.getTotalMaintenanceRate(state) ==
+            CHECK(metabolics_smooth_huber.getTotalActivationRate(state) ==
                     Approx(0.0));
+            CHECK(metabolics_smooth_tanh.getTotalMaintenanceRate(state) ==
+                    Approx(0.0));
+            CHECK(metabolics_smooth_huber.getTotalMaintenanceRate(state) ==
+                    Approx(0.0));
+
         }
 
         SECTION("mechanicalWorkRate=-fiberForceActive * fiberVelocity with "
@@ -245,14 +335,22 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             CHECK(mechanicalWorkRate_nonSmooth ==
                     metabolics_negativeWork_nonSmooth.
                             getTotalMechanicalWorkRate(state));
-            // Smooth metabolics model.
-            double mechanicalWorkRate_smooth =
-                    - metabolics_negativeWork_smooth.
+            // Smooth metabolics models.
+            double mechanicalWorkRate_smooth_tanh =
+                    - metabolics_negativeWork_smooth_tanh.
                             get_muscle_effort_scaling_factor() *
                     muscle.getActiveFiberForce(state) *
                     muscle.getFiberVelocity(state);
-            CHECK(mechanicalWorkRate_smooth ==
-                    metabolics_negativeWork_smooth.
+            CHECK(mechanicalWorkRate_smooth_tanh ==
+                    metabolics_negativeWork_smooth_tanh.
+                            getTotalMechanicalWorkRate(state));
+            double mechanicalWorkRate_smooth_huber =
+                    - metabolics_negativeWork_smooth_huber.
+                            get_muscle_effort_scaling_factor() *
+                    muscle.getActiveFiberForce(state) *
+                    muscle.getFiberVelocity(state);
+            CHECK(mechanicalWorkRate_smooth_huber ==
+                    metabolics_negativeWork_smooth_huber.
                             getTotalMechanicalWorkRate(state));
 
             // Eccentric contraction
@@ -274,14 +372,22 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             CHECK(mechanicalWorkRate_nonSmooth ==
                     metabolics_negativeWork_nonSmooth.
                             getTotalMechanicalWorkRate(state));
-            // Smooth metabolics model.
-            mechanicalWorkRate_smooth =
-                    - metabolics_negativeWork_smooth.
+            // Smooth metabolics models.
+            mechanicalWorkRate_smooth_tanh =
+                    - metabolics_negativeWork_smooth_tanh.
                             get_muscle_effort_scaling_factor() *
                     muscle.getActiveFiberForce(state) *
                     muscle.getFiberVelocity(state);
-            CHECK(mechanicalWorkRate_smooth ==
-                    metabolics_negativeWork_smooth.
+            CHECK(mechanicalWorkRate_smooth_tanh ==
+                    metabolics_negativeWork_smooth_tanh.
+                            getTotalMechanicalWorkRate(state));
+            mechanicalWorkRate_smooth_huber =
+                    - metabolics_negativeWork_smooth_huber.
+                            get_muscle_effort_scaling_factor() *
+                    muscle.getActiveFiberForce(state) *
+                    muscle.getFiberVelocity(state);
+            CHECK(mechanicalWorkRate_smooth_huber ==
+                    metabolics_negativeWork_smooth_huber.
                             getTotalMechanicalWorkRate(state));
         }
 
@@ -302,9 +408,11 @@ TEST_CASE("Bhargava2004Metabolics basics") {
             // Non-smooth metabolics model.
             CHECK(mechanicalWorkRate ==
                     metabolics_nonSmooth.getTotalMechanicalWorkRate(state));
-            // Smooth metabolics model.
+            // smooth metabolics models.
             CHECK(mechanicalWorkRate ==
-                    metabolics_smooth.getTotalMechanicalWorkRate(state));
+                    metabolics_smooth_tanh.getTotalMechanicalWorkRate(state));
+            CHECK(mechanicalWorkRate ==
+                    metabolics_smooth_huber.getTotalMechanicalWorkRate(state));
         }
 
         SECTION("Total power is clamped so that it is always non-negative") {
@@ -343,24 +451,44 @@ TEST_CASE("Bhargava2004Metabolics basics") {
                     maintenanceHeatRate_nonSmooth +
                     shorteningHeatRate_nonSmooth +
                     mechanicalWorkRate_nonSmooth;
-            // Smooth metabolics model.
-            double activationHeatRate_smooth =
-                    metabolics_negativeWork_smooth.
+            // Smooth metabolics models.
+            double activationHeatRate_smooth_tanh =
+                    metabolics_negativeWork_smooth_tanh.
                             getTotalActivationRate(state);
-            double maintenanceHeatRate_smooth =
-                    metabolics_negativeWork_smooth.
+            double maintenanceHeatRate_smooth_tanh =
+                    metabolics_negativeWork_smooth_tanh.
                             getTotalMaintenanceRate(state);
-            double shorteningHeatRate_smooth =
-                    metabolics_negativeWork_smooth.
+            double shorteningHeatRate_smooth_tanh =
+                    metabolics_negativeWork_smooth_tanh.
                             getTotalShorteningRate(state);
-            double mechanicalWorkRate_smooth =
-                    metabolics_negativeWork_smooth.
+            double mechanicalWorkRate_smooth_tanh =
+                    metabolics_negativeWork_smooth_tanh.
                             getTotalMechanicalWorkRate(state);
-            double Edot_clamped_smooth =
-                    activationHeatRate_smooth + maintenanceHeatRate_smooth +
-                    shorteningHeatRate_smooth + mechanicalWorkRate_smooth;
+            double Edot_clamped_smooth_tanh =
+                    activationHeatRate_smooth_tanh +
+                    maintenanceHeatRate_smooth_tanh +
+                    shorteningHeatRate_smooth_tanh +
+                    mechanicalWorkRate_smooth_tanh;
+             double activationHeatRate_smooth_huber =
+                    metabolics_negativeWork_smooth_huber.
+                            getTotalActivationRate(state);
+            double maintenanceHeatRate_smooth_huber =
+                    metabolics_negativeWork_smooth_huber.
+                            getTotalMaintenanceRate(state);
+            double shorteningHeatRate_smooth_huber =
+                    metabolics_negativeWork_smooth_huber.
+                            getTotalShorteningRate(state);
+            double mechanicalWorkRate_smooth_huber =
+                    metabolics_negativeWork_smooth_huber.
+                            getTotalMechanicalWorkRate(state);
+            double Edot_clamped_smooth_huber =
+                    activationHeatRate_smooth_huber +
+                    maintenanceHeatRate_smooth_huber +
+                    shorteningHeatRate_smooth_huber +
+                    mechanicalWorkRate_smooth_huber;
             double Edot_clamped = 0.0;
-            CHECK(Edot_clamped == Edot_clamped_smooth);
+            CHECK(Edot_clamped == Edot_clamped_smooth_tanh);
+            CHECK(Edot_clamped == Edot_clamped_smooth_huber);
             CHECK(Edot_clamped == Edot_clamped_nonSmooth);
         }
 
@@ -416,37 +544,63 @@ TEST_CASE("Bhargava2004Metabolics basics") {
                     - mechanicalWorkRate_nonSmooth - metabolics_nonSmooth.
                             get_muscle_parameters(0).getMuscleMass() ==
                                     Approx(0.0).margin(1e-4));
-            // Smooth metabolics model.
-            double activationHeatRate_smooth =
-                    metabolics_smooth.getTotalActivationRate(state);
-            double maintenanceHeatRate_smooth =
-                    metabolics_smooth.getTotalMaintenanceRate(state);
-            double shorteningHeatRate_smooth =
-                    metabolics_smooth.getTotalShorteningRate(state);
-            double totalHeatRate_smooth = activationHeatRate_smooth +
-                    maintenanceHeatRate_smooth + shorteningHeatRate_smooth;
+            // Smooth metabolics models.
+            double activationHeatRate_smooth_tanh =
+                    metabolics_smooth_tanh.getTotalActivationRate(state);
+            double maintenanceHeatRate_smooth_tanh =
+                    metabolics_smooth_tanh.getTotalMaintenanceRate(state);
+            double shorteningHeatRate_smooth_tanh =
+                    metabolics_smooth_tanh.getTotalShorteningRate(state);
+            double totalHeatRate_smooth_tanh = activationHeatRate_smooth_tanh +
+                    maintenanceHeatRate_smooth_tanh +
+                    shorteningHeatRate_smooth_tanh;
+            double activationHeatRate_smooth_huber =
+                    metabolics_smooth_huber.getTotalActivationRate(state);
+            double maintenanceHeatRate_smooth_huber =
+                    metabolics_smooth_huber.getTotalMaintenanceRate(state);
+            double shorteningHeatRate_smooth_huber =
+                    metabolics_smooth_huber.getTotalShorteningRate(state);
+            double totalHeatRate_smooth_huber =
+                    activationHeatRate_smooth_huber +
+                    maintenanceHeatRate_smooth_huber +
+                    shorteningHeatRate_smooth_huber;
             // Check that the total heat rate before clamping (i.e., activation
             // heat rate + maintenance heat rate + shortening heat rate) is
             // below 1.0 W/kg so that it will be clamped to 1.0 W/kg when
             // enforce_minimum_heat_rate_per_muscle() is true (default).
-            CHECK(totalHeatRate_smooth <
-                    metabolics_smooth.get_muscle_parameters(0).
+            CHECK(totalHeatRate_smooth_tanh <
+                    metabolics_smooth_tanh.get_muscle_parameters(0).
                             getMuscleMass());
-            double mechanicalWorkRate_smooth =
-                    metabolics_smooth.getTotalMechanicalWorkRate(state);
-            double totalMetabolicRate_smooth =
-                    metabolics_smooth.getTotalMetabolicRate(state);
-            double basalRate_smooth =
-                    metabolics_smooth.get_basal_coefficient() *
+            CHECK(totalHeatRate_smooth_huber <
+                    metabolics_smooth_huber.get_muscle_parameters(0).
+                            getMuscleMass());
+            double mechanicalWorkRate_smooth_tanh =
+                    metabolics_smooth_tanh.getTotalMechanicalWorkRate(state);
+            double totalMetabolicRate_smooth_tanh =
+                    metabolics_smooth_tanh.getTotalMetabolicRate(state);
+            double basalRate_smooth_tanh =
+                    metabolics_smooth_tanh.get_basal_coefficient() *
                     pow(model.getMatterSubsystem().calcSystemMass(state),
-                            metabolics_smooth.get_basal_exponent());
+                            metabolics_smooth_tanh.get_basal_exponent());
+            double mechanicalWorkRate_smooth_huber =
+                    metabolics_smooth_huber.getTotalMechanicalWorkRate(state);
+            double totalMetabolicRate_smooth_huber =
+                    metabolics_smooth_huber.getTotalMetabolicRate(state);
+            double basalRate_smooth_huber =
+                    metabolics_smooth_huber.get_basal_coefficient() *
+                    pow(model.getMatterSubsystem().calcSystemMass(state),
+                            metabolics_smooth_huber.get_basal_exponent());
             // Check that the total heat rate after clamping (i.e., total
             // metabolic rate - basal rate - mechanical work rate) is
             // equal to the muscle mass (i.e., clamped to 1.0 W/kg).
-            CHECK(totalMetabolicRate_smooth - basalRate_smooth
-                    - mechanicalWorkRate_smooth - metabolics_smooth.
+            CHECK(totalMetabolicRate_smooth_tanh - basalRate_smooth_tanh
+                    - mechanicalWorkRate_smooth_tanh - metabolics_smooth_tanh.
                             get_muscle_parameters(0).getMuscleMass() ==
                                     Approx(0.0).margin(1e-4));
+            CHECK(totalMetabolicRate_smooth_huber - basalRate_smooth_huber
+                    - mechanicalWorkRate_smooth_huber -
+                            metabolics_smooth_huber.get_muscle_parameters(0).
+                            getMuscleMass() == Approx(0.0).margin(1e-4));
         }
 
     }


### PR DESCRIPTION
@chrisdembia and @nickbianco, this is a first try for the Huber loss function. It is not yet complete but I would be interested to have feedback on a few things:

1. Would you keep both smoothing options available, ie tanh vs Huber loss?

2. I thought I solved it but I am actually still struggling with one case. For the shortening heat rate, when `use_force_dependent_shortening_prop_constant` is `true`, the shortening heat rate is not 0 when the fiber velocity is > 0 (see curves Figure 1 (left) below). This makes a little trickier the use of the Huber loss function as I implemented it. What I did is that I rotated the curve, used the Huber loss function, and the rotated back. As you can see in the figure, this looks good (although very steep). However, I did not think that, in practice, we do not have access to the value before rotation, since that value depends on a if-statement that we want to avoid...So basically, for now, [my ugly code implementing this rotation thing](https://github.com/opensim-org/opensim-moco/blob/bhargava_smooth_huber/Moco/Moco/Components/Bhargava2004Metabolics.cpp#L458) depends on a value I get out of [this if-statement](https://github.com/opensim-org/opensim-moco/blob/bhargava_smooth_huber/Moco/Moco/Components/Bhargava2004Metabolics.cpp#L431), which is certainly not what we want. I think it should be feasible to avoid this rotation and to directly apply the Huber loss function (this might also allow having a smoother transition I think). Any ideas?

3. I have tried to keep the same structure (i.e., `m_conditional`) when implementing the Huber loss function. Not sure this is what we want.

4. All the tests pass but the problem did not converge (point 2 above did not matter, since  `use_force_dependent_shortening_prop_constant` was`true`). I got `restoration failed` after about 1h. Maybe it is to steep, not sure...

I attach the MATLAB code I used if you want to give it a shot. If you run it, you should get the figures for the different cases where smoothing is applied.

Those are my thought for now. Thanks in advance. I hope we can get that bhargava_smooth PR done soon, it is getting long :)

![ShorteningRate](https://user-images.githubusercontent.com/19328993/86046394-71a35880-ba4d-11ea-9b1f-99d341818e5c.png)

[testMetabolicEnergyModel_HuberLoss4.zip](https://github.com/opensim-org/opensim-moco/files/4847591/testMetabolicEnergyModel_HuberLoss4.zip)

### Brief summary of changes

Give option to use a Huber loss function rather than a tanh function.



### Details (optional)

### CHANGELOG.md (choose one)

- [ ] updated
- [ ] no need to update because...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/649)
<!-- Reviewable:end -->
