### PR TITLE
Made Eigen dependency download from GitLab, rather than bitbucket

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -185,7 +185,8 @@ SetDefaultCMakeBuildType()
 ####################### Add dependencies below.
 
 AddDependency(NAME eigen
-              URL  https://bitbucket.org/eigen/eigen/get/3.3.7.zip)
+	      GIT_URL https://gitlab.com/libeigen/eigen.git
+	      GIT_TAG 3.3.7)
 
 include(colpack.cmake)
 


### PR DESCRIPTION
I know moco's in the process of being merged, so feel free to ignore this upstream PR.

I'm currently trying to build moco on Linux for some research work. The scripts all mostly work fine, but I had an issue with downloading Eigen from bitbucket (I think it's been closed down?). Anyway, this is a minor change that pulls from Eigen's central repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/656)
<!-- Reviewable:end -->
