### PR TITLE
Made build_on_linux detect the number of available build threads

### DIFF
--- a/build_on_linux.sh
+++ b/build_on_linux.sh
@@ -1,12 +1,16 @@
 #/bin/bash
+
+NUM_BUILD_JOBS=${NUM_BUILD_JOBS:-$(nproc)}
+
 git submodule update --init
 mkdir ../moco_dependencies_build
 cd ../moco_dependencies_build
 cmake ../opensim-moco/dependencies
-make --jobs 4 ipopt
-make --jobs 4
+make --jobs "${NUM_BUILD_JOBS}" ipopt
+make --jobs "${NUM_BUILD_JOBS}"
 cd ..
 mkdir build
 cd build
 cmake ../opensim-moco 
-make --jobs 4
+make --jobs "${NUM_BUILD_JOBS}"
+


### PR DESCRIPTION
Again, this is a driveby patch. Just close it off if you don't want it. It's just a modification I made because I was building on a 16T workstation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/657)
<!-- Reviewable:end -->
