### PR TITLE
Add -fallow-argument-mismatch flag

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -289,7 +289,9 @@ else()
                   COMMAND cd <SOURCE_DIR>/ThirdParty/Metis && ./get.Metis
                   COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && patch < ${CMAKE_SOURCE_DIR}/get.Mumps.patch
                   COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && ./get.Mumps
-            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+            # GCC 10 generates a warning when compiling MUMPS that we must suppress using
+            # -fallow-argument-mismatch.
+            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch
             BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
             INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install)
     endif()


### PR DESCRIPTION
### Brief summary of changes

Add the flag `-fallow-argument-mismatch` to suppress warnings generated by GCC 10 when compiling MUMPS.

### CHANGELOG.md (choose one)

- [ ] updated
- [x] no need to update because...minor build fix, not user facing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/659)
<!-- Reviewable:end -->
