### PR TITLE
add missing type API + upgrade java

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -224,7 +224,7 @@ jobs:
         cmake . -LAH
         VERSION=`cmake -L . | grep MOCO_FULL_VERSION | cut -d "=" -f2`
         echo $VERSION
-        echo "::set-env name=VERSION::$VERSION"
+        echo "VERSION=$version" >> $GITHUB_ENV
         echo "::set-output name=version::$VERSION"
         
     - name: Build Moco

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
         7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-        echo "::add-path::$env:GITHUB_WORKSPACE\\doxygen"
+        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
 
     - name: Install NumPy 
       run: python -m pip install numpy

--- a/Moco/Bindings/Java/CMakeLists.txt
+++ b/Moco/Bindings/Java/CMakeLists.txt
@@ -145,7 +145,7 @@ add_custom_command(
             ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
     COMMAND ${JAVA_COMPILE} 
             org/opensim/modeling/*.java 
-            -source 1.6 -target 1.6
+            -source 1.7 -target 1.7
     COMMAND ${JAVA_ARCHIVE} -cvf ${SWIG_JAVA_JAR_NAME}
             org/opensim/modeling/*.class
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src

--- a/Moco/Moco/RegisterTypes_osimMoco.cpp
+++ b/Moco/Moco/RegisterTypes_osimMoco.cpp
@@ -68,6 +68,7 @@ static osimMocoInstantiator instantiator;
 OSIMMOCO_API void RegisterTypes_osimMoco() {
     try {
         Object::registerType(MocoFinalTimeGoal());
+        Object::registerType(MocoAverageSpeedGoal());
         Object::registerType(MocoWeight());
         Object::registerType(MocoWeightSet());
         Object::registerType(MocoStateTrackingGoal());

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -292,7 +292,7 @@ else()
                   COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && ./get.Mumps
             # GCC 10 generates a warning when compiling MUMPS that we must suppress using
             # -fallow-argument-mismatch.
-            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch
+            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch ADD_CFLAGS=-Wno-error=implicit-function-declaration
             BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
             INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install)
     endif()


### PR DESCRIPTION
Fixes issue #662 

### Brief summary of changes

Add `MocoAverageSpeedGoal` as a `registerType`.
Upgrade java source and target versions to prevent issues when building the bindings.

### Details (optional)

### CHANGELOG.md (choose one)

- no need to update because very minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-moco/663)
<!-- Reviewable:end -->
